### PR TITLE
Fix all ty errors and make ty check blocking in CI

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -32,12 +32,7 @@ jobs:
       run: poetry run ruff check .
     - name: ty check
       working-directory: ${{ matrix.package }}
-      # py-endgame-aws is clean, so ty gates it. py-endgame still has a
-      # pre-existing backlog of type errors that needs triage, so there it
-      # only runs to show up in the log -- drop this `continue-on-error`
-      # entirely once that backlog is cleared.
       run: poetry run ty check .
-      continue-on-error: ${{ matrix.package != 'py-endgame-aws' }}
 
   make-push:
     needs: lint

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -32,12 +32,12 @@ jobs:
       run: poetry run ruff check .
     - name: ty check
       working-directory: ${{ matrix.package }}
-      # Not blocking yet: there's a real pre-existing backlog of type
-      # errors (some already deliberately `# type: ignore`d under mypy)
-      # that needs triage before this can gate the push. Still runs so
-      # it shows up in the log.
+      # py-endgame-aws is clean, so ty gates it. py-endgame still has a
+      # pre-existing backlog of type errors that needs triage, so there it
+      # only runs to show up in the log -- drop this `continue-on-error`
+      # entirely once that backlog is cleared.
       run: poetry run ty check .
-      continue-on-error: true
+      continue-on-error: ${{ matrix.package != 'py-endgame-aws' }}
 
   make-push:
     needs: lint

--- a/py-endgame-aws/endgame_aws/io.py
+++ b/py-endgame-aws/endgame_aws/io.py
@@ -4,7 +4,7 @@ import pickle
 from csv import DictReader, DictWriter
 from dataclasses import dataclass
 from io import StringIO
-from typing import AsyncIterator, Type, TypeVar
+from typing import Any, AsyncIterator, Type, TypeVar
 
 from aiobotocore.session import get_session
 from botocore.exceptions import ClientError
@@ -14,15 +14,58 @@ from endgame.ncaabb.ncaabb import Season
 from endgame.ncaabb.possession_side import PossessionSide
 
 
-class _SerializablePossession(PossessionSide, DataClassJsonMixin):  # type: ignore[misc]
-    # Ignore mypy because this double-defines to_dict, but it's unused anyway
-    pass
+class _SerializablePossession(PossessionSide, DataClassJsonMixin):
+    # Both bases define `to_dict`, with signatures neither a type checker nor
+    # the MRO can reconcile: `PossessionSide.to_dict()` takes no arguments and
+    # returns `dict[str, Primitive]`, while `DataClassJsonMixin.to_dict()`
+    # takes `encode_json` and returns `dict[str, Json]`. Spell out an override
+    # that both bases accept -- it delegates to the `PossessionSide` one, which
+    # is what the MRO already picked, so this is only making the resolution
+    # explicit. This class is only used for its `schema()`, anyway.
+    def to_dict(self, encode_json: bool = False) -> dict[str, Any]:
+        return PossessionSide.to_dict(self)
 
 
 @dataclass
 class FlattenedBoxScore(PlayerBoxScore, DataClassJsonMixin):
     game_id: str
     team_id: str
+
+    @classmethod
+    def from_player(
+        cls, player: PlayerBoxScore, *, game_id: str, team_id: str
+    ) -> "FlattenedBoxScore":
+        """
+        Build a flattened row from a player's box score plus the ids of the
+        game and team it came from.
+
+        Copies the fields out one by one rather than splatting
+        `**player.to_dict()`: the dict is typed as `dict[str, Json]`, so
+        splatting it hides every field from the type checker. Written out, a
+        new field on `PlayerBoxScore` shows up here as a missing argument.
+        """
+        return cls(
+            player_id=player.player_id,
+            short_name=player.short_name,
+            minutes_played=player.minutes_played,
+            field_goal_makes=player.field_goal_makes,
+            field_goal_attempts=player.field_goal_attempts,
+            three_point_makes=player.three_point_makes,
+            three_point_attempts=player.three_point_attempts,
+            free_throw_makes=player.free_throw_makes,
+            free_throw_attempts=player.free_throw_attempts,
+            offensive_rebounds=player.offensive_rebounds,
+            defensive_rebounds=player.defensive_rebounds,
+            rebounds=player.rebounds,
+            assists=player.assists,
+            steals=player.steals,
+            blocks=player.blocks,
+            turnovers=player.turnovers,
+            fouls=player.fouls,
+            points=player.points,
+            game_id=game_id,
+            team_id=team_id,
+        )
 
 
 async def save_to_s3(seasons: list[Season], bucket: str, key: str):

--- a/py-endgame-aws/main.py
+++ b/py-endgame-aws/main.py
@@ -111,16 +111,16 @@ async def box_scores(gender_name: str, year: int):
     pulled_game_ids = {side.game_id for side in box_score_rows_so_far}
     async for box_score in get_season_box_scores(season, gender, pulled_game_ids):
         box_score_rows.extend(
-            FlattenedBoxScore(
-                **player.to_dict(),  # type: ignore[arg-type]
+            FlattenedBoxScore.from_player(
+                player,
                 team_id=box_score.home.team_id,
                 game_id=box_score.game_id,
             ).to_dict()
             for player in box_score.home.players
         )
         box_score_rows.extend(
-            FlattenedBoxScore(
-                **player.to_dict(),  # type: ignore[arg-type]
+            FlattenedBoxScore.from_player(
+                player,
                 team_id=box_score.away.team_id,
                 game_id=box_score.game_id,
             ).to_dict()

--- a/py-endgame/endgame/date.py
+++ b/py-endgame/endgame/date.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Tuple
 
 
@@ -12,5 +12,5 @@ def get_end_year(season_end: Tuple[int, int]) -> int:
     EX: if the most recent NFL season is 2019-2020,
     this will return 2019.
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return now.year - 1 if (now.month, now.day) < season_end else now.year

--- a/py-endgame/endgame/ncaabb/box_score/all.py
+++ b/py-endgame/endgame/ncaabb/box_score/all.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from typing import AsyncIterator, Iterable, Iterator, List, Optional
 
-from aiohttp.client_exceptions import ClientResponseError
+from aiohttp import ClientResponseError
 from bs4 import BeautifulSoup, Tag
 from dataclasses_json import DataClassJsonMixin
 
@@ -179,8 +179,23 @@ def _get_td_text(tag: Tag) -> str:
     return td.text
 
 
+def _get_str_attr(tag: Tag, name: str) -> str:
+    """
+    Read a single-valued attribute off a tag.
+
+    `Tag.attrs` values are `str | AttributeValueList`, because bs4 hands back a
+    list for multi-valued attributes like `class`. The attributes read here are
+    single-valued, so a list means the page isn't shaped the way this parser
+    expects.
+    """
+    value = tag.attrs[name]
+    if not isinstance(value, str):
+        raise _ParseError
+    return value
+
+
 def _get_team_id(team_name_tag: Tag) -> str:
-    team_link = team_name_tag.attrs["href"]
+    team_link = _get_str_attr(team_name_tag, "href")
     # This link hopefully always looks like:
     # /womens-college-basketball/team/_/id/12/arizona-wildcats
     return team_link.split("/")[-2]
@@ -214,7 +229,7 @@ def _parse_player(
     player: Tag, columns: List[str], stat_values: List[str], team_id: str
 ) -> RawPlayer:
     if player_link := player.select_one("td a"):
-        href = player_link.attrs["href"]
+        href = _get_str_attr(player_link, "href")
         *_, player_id, short_name = href.split("/")
     else:
         # If there's no ID, use the team+player name to make an ID

--- a/py-endgame/endgame/ncaabb/matchup.py
+++ b/py-endgame/endgame/ncaabb/matchup.py
@@ -58,7 +58,7 @@ async def get_possessions(
     url = URL_FORMAT.format(gender=gender.name, game_id=game_id)
     try:
         content = await get(url)
-    except aiohttp.client_exceptions.ClientResponseError as error:
+    except aiohttp.ClientResponseError as error:
         if error.code == 404:
             return None
         raise error

--- a/py-endgame/endgame/ncaabb/ncaabb.py
+++ b/py-endgame/endgame/ncaabb/ncaabb.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from itertools import groupby
 from logging import getLogger
@@ -78,8 +78,13 @@ async def get_seasons(gender: NcaabbGender) -> List[Season]:
     Get all seasons for a NCAABB
     """
     end_year = get_end_year(SEASON_END)
-    args = [(y, gender) for y in range(2001, end_year + 1)]
-    return [s async for s in apply_in_parallel(get_ncaabb_season, args)]
+    # `apply_in_parallel` binds every parameter of the callable it's handed,
+    # including `get_ncaabb_season`'s two defaulted ones, so wrap it to take
+    # just the year rather than padding every tuple out with `None`s.
+    args = [(y,) for y in range(2001, end_year + 1)]
+    return [
+        s async for s in apply_in_parallel(lambda y: get_ncaabb_season(y, gender), args)
+    ]
 
 
 def _last_day_so_far(season_so_far: Season | None) -> date | None:
@@ -128,7 +133,7 @@ async def get_ncaabb_season(
     for day_param in day_params:
         try:
             games += await get_ncaabb_games(*day_param)
-        except aiohttp.client_exceptions.ClientResponseError:
+        except aiohttp.ClientResponseError:
             day, gender, group = day_param
             logger.warning(
                 "Marking %s for %s %s as trouble", day, gender.name, group.name
@@ -139,7 +144,9 @@ async def get_ncaabb_season(
     if season_so_far:
         season = merge_seasons([season_so_far, season])
 
-    if datetime.utcnow() > datetime(year + 1, *SEASON_END):
+    if datetime.now(timezone.utc) > datetime(
+        year + 1, *SEASON_END, tzinfo=timezone.utc
+    ):
         cache.save_to_cache(season)
 
     return season

--- a/py-endgame/endgame/ncaafb.py
+++ b/py-endgame/endgame/ncaafb.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import groupby
 from logging import getLogger
 from typing import AsyncIterator, Iterator, List
@@ -28,7 +28,7 @@ async def update(location="ncaaf.csv"):
     Update the NCAAFB data
     """
     end_year = get_end_year(SEASON_END)
-    args = [[y] for y in range(1999, end_year + 1)]
+    args = [(y,) for y in range(1999, end_year + 1)]
     seasons = [s async for s in apply_in_parallel(get_season, args)]
     save_seasons(seasons, location)
 
@@ -57,7 +57,7 @@ async def get_season(year: int) -> Season:
             week = await _get_week(*week_param)
             weeks.append(week)
         # Should I raise custom exception instead?
-        except aiohttp.client_exceptions.ClientResponseError:
+        except aiohttp.ClientResponseError:
             year, week_num, season_type, group = week_param
             msg = (
                 f"Marking week as trouble: "
@@ -70,8 +70,8 @@ async def get_season(year: int) -> Season:
     season = Season(weeks, year, trouble_weeks)
 
     # Cache if the season is over
-    season_end_date = datetime(year + 1, *SEASON_END)
-    if datetime.utcnow() > season_end_date:
+    season_end_date = datetime(year + 1, *SEASON_END, tzinfo=timezone.utc)
+    if datetime.now(timezone.utc) > season_end_date:
         cache.save_to_cache(season)
 
     return season

--- a/py-endgame/endgame/nfl/coaches.py
+++ b/py-endgame/endgame/nfl/coaches.py
@@ -2,7 +2,7 @@ from csv import DictWriter
 from dataclasses import dataclass
 from typing import AsyncIterable, Dict, Tuple, Union
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from ..web import get
 from .teams import PRO_FOOTBALL_REFERENCE_SHORT_NAMES, NflTeam
@@ -70,7 +70,10 @@ async def get_coaches(year: int) -> AsyncIterable[Tuple[str, NflTeam]]:
     """
     content = await get(URL_FORMAT.format(year=year))
     soup = BeautifulSoup(content.data, features="html.parser")
-    rows = soup.find(id="coaches").find_all("tr")  # type: ignore[union-attr]
+    coaches_table = soup.find(id="coaches")
+    if not isinstance(coaches_table, Tag):
+        raise ValueError(f"No coaches table on the {year} coaches page")
+    rows = coaches_table.find_all("tr")
     _, column_headers, *data_rows = rows
     column_names = [h.text for h in column_headers.find_all("th")]
 

--- a/py-endgame/endgame/nfl/games.py
+++ b/py-endgame/endgame/nfl/games.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import getLogger
 from typing import AsyncIterator
 
@@ -86,8 +86,8 @@ async def get_season(year: int) -> Season:
     season = Season(weeks, year)
 
     # Cache if the season is over
-    season_end_date = datetime(year + 1, *SEASON_END)
-    if datetime.utcnow() > season_end_date:
+    season_end_date = datetime(year + 1, *SEASON_END, tzinfo=timezone.utc)
+    if datetime.now(timezone.utc) > season_end_date:
         cache.save_to_cache(season)
 
     return season

--- a/py-endgame/endgame/nfl/spread.py
+++ b/py-endgame/endgame/nfl/spread.py
@@ -73,12 +73,21 @@ async def get_spreads(week: str) -> AsyncIterable[Game]:
     tables = soup.find_all("table")
 
     for table in tables:
-        if row := table.findChild("tr", recursive=False):
-            if td_tag := row.findChild("td", recursive=False):
-                if center := td_tag.findChild("center", recursive=False):
-                    games = _to_games(td_tag, center.text)
-                    for game in games:
-                        yield game
+        # `findChild` has been a deprecated alias for `find` since bs4 3.0, and
+        # its shim doesn't take `recursive`. Each `find` can also come back as a
+        # `NavigableString`, which the `Tag` checks below rule out -- a bare
+        # truthiness check wouldn't, since `NavigableString` is a `str`.
+        row = table.find("tr", recursive=False)
+        if not isinstance(row, Tag):
+            continue
+        td_tag = row.find("td", recursive=False)
+        if not isinstance(td_tag, Tag):
+            continue
+        center = td_tag.find("center", recursive=False)
+        if not isinstance(center, Tag):
+            continue
+        for game in _to_games(td_tag, center.text):
+            yield game
 
     await content.save_if_necessary()
 

--- a/py-endgame/endgame/web.py
+++ b/py-endgame/endgame/web.py
@@ -71,10 +71,10 @@ async def _get_with_retries(url: str, parameters: RequestParameters) -> bytes:
         try:
             return await _get_web(url, parameters)
         except (
-            aiohttp.client_exceptions.ClientResponseError,
-            aiohttp.client_exceptions.ClientConnectorError,
-            aiohttp.client_exceptions.ClientPayloadError,
-            aiohttp.client_exceptions.ServerDisconnectedError,
+            aiohttp.ClientResponseError,
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientPayloadError,
+            aiohttp.ServerDisconnectedError,
         ) as error:
             if i + 1 == max_retries:
                 raise error
@@ -95,13 +95,13 @@ async def _get_with_retries(url: str, parameters: RequestParameters) -> bytes:
 
 def _get_error_message(
     error: Union[
-        aiohttp.client_exceptions.ClientResponseError,
-        aiohttp.client_exceptions.ClientConnectorError,
-        aiohttp.client_exceptions.ClientPayloadError,
-        aiohttp.client_exceptions.ServerDisconnectedError,
+        aiohttp.ClientResponseError,
+        aiohttp.ClientConnectorError,
+        aiohttp.ClientPayloadError,
+        aiohttp.ServerDisconnectedError,
     ],
 ) -> str:
-    if isinstance(error, aiohttp.client_exceptions.ClientResponseError):
+    if isinstance(error, aiohttp.ClientResponseError):
         return f"Status code: {error.status}"
     return str(error)
 


### PR DESCRIPTION
`ty check` was running in CI with `continue-on-error: true`, so type errors never blocked anything. Both packages are now clean and `continue-on-error` is gone entirely.

| package | before | after |
| --- | --- | --- |
| `py-endgame-aws` | 37 diagnostics | clean |
| `py-endgame` | 22 diagnostics | clean |

Two commits, one per package, if that's easier to read separately.

## py-endgame-aws (37 → 0)

All from three sites, all masked by mypy-style `# type: ignore[...]` comments that ty doesn't honor.

**`_SerializablePossession` — `invalid-method-override`** (1). Both bases define `to_dict` with irreconcilable signatures: `PossessionSide.to_dict(self) -> Dict[str, Primitive]` vs `DataClassJsonMixin.to_dict(self, encode_json=False) -> Dict[str, Json]`. No single return type satisfies both (`Dict` is invariant), so there's now an explicit override that both accept, delegating to the `PossessionSide` one — which is what the MRO already resolved to, so runtime is unchanged. The class is only used for its `schema()` anyway, as the original comment noted.

**`FlattenedBoxScore(**player.to_dict(), ...)` — `invalid-argument-type`** (36, two call sites × 18 fields). `to_dict()` is typed `dict[str, Json]`, so splatting it hid every field. Replaced with a `FlattenedBoxScore.from_player` classmethod that copies fields explicitly — a new field on `PlayerBoxScore` now surfaces as a missing argument instead of passing silently — and it dedupes the identical home/away blocks in `main.py`.

## py-endgame (22 → 0)

**`aiohttp.client_exceptions.X`** (12). `aiohttp/__init__.py` lazy-loads unknown attributes through a `__getattr__` returning `object`, so the private submodule path resolved to nothing. All four exception classes are re-exported at the top level, so this now uses `aiohttp.ClientResponseError` etc. Also normalized `box_score/all.py`'s `from aiohttp.client_exceptions import ...` to the public spelling.

**`datetime.utcnow()`** (4, `deprecated` warnings — which ty also exits non-zero on). Replaced with `datetime.now(timezone.utc)`, making the season-end dates they're compared against aware too, so the comparisons stay valid rather than raising on naive-vs-aware.

**`Tag.attrs["href"]`** (2). Typed `str | AttributeValueList`, since bs4 returns a list for multi-valued attributes like `class`. Added a `_get_str_attr` helper that narrows and raises the existing `_ParseError` otherwise.

**`apply_in_parallel` args** (2). Its `Callable[[*Ts], ...]` binds *every* parameter, including defaulted ones, so `get_ncaabb_season` needed a 1-arg wrapper rather than padding each tuple with `None`s. Separately, `ncaafb` passed `list[list[int]]` where the signature says tuple — that only worked because the call site splats it.

**`soup.find(id="coaches").find_all(...)`** (1). `find` can return `NavigableString | None`. Narrowed with `isinstance`, raising a real error instead of an `AttributeError` if that table ever moves.

**`findChild(..., recursive=False)`** (1). Deprecated alias for `find` since bs4 3.0, and its shim doesn't accept `recursive`. Switched to `find`, using `Tag` checks rather than truthiness — `NavigableString` subclasses `str`, so the old walrus chain wouldn't have rejected one.

## Verification

Both packages, Python 3.12, `poetry install`:

- `ty check .` → clean (was 37 / 22)
- `ruff format --check .` and `ruff check .` → clean

The `py-endgame` changes touch parsing paths that the test suite doesn't cover, so I checked them for equivalence offline:

- the `spread.py` loop selects the same tags as the old `findChild` chain across a table fixture (missing `tr`/`td`/`center`, `th` instead of `td`, bare text)
- `_get_team_id` output unchanged; a multi-valued attribute correctly raises `_ParseError`
- the `apply_in_parallel` wrapper issues byte-identical calls: `(2001, 'womens', None, None)`, …
- aware/naive comparison matches for every `SEASON_END` in the repo across 1999–2030
- `FlattenedBoxScore(**p.to_dict(), ...) == FlattenedBoxScore.from_player(p, ...)`, identical `to_dict()`; `_SerializablePossession.schema().load(row)` unchanged including `str` → `bool`/`int` coercion

`py-endgame` tests: **38 passed, 2 failed**. Both failures are `plays_test.py` hitting ESPN and getting a 403 from my sandbox, and they reproduce identically on the base commit. CI doesn't run pytest. `py-endgame-aws`'s only test hits real S3, so it wasn't run either; `stores.py` is untouched.

One note: `py-endgame-aws` pins `endgame` to git rev `5024e1a`, so it type-checks against the *old* `py-endgame`. The pin is unchanged here — bumping it is a separate call.