### PR TITLE
Cache layers in ECR instead of the Actions cache, and push from the builder

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -49,22 +49,22 @@ jobs:
         fetch-depth: 0  # Needed to get the full git history for rev-parse
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Expose the Actions cache to buildx
-      # buildx's `type=gha` backend needs these, but the runner only exposes
-      # them to actions -- not to plain `run:` steps. Re-exporting them here
-      # lets the bare `docker buildx build` inside the Makefile use the cache,
-      # so CI and local builds stay one build definition.
-      # ACTIONS_RESULTS_URL is for the v2 cache API; without it, recent buildx
-      # versions can't reach the cache service at all.
-      uses: actions/github-script@v7
-      with:
-        script: |
-          for (const v of ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_CACHE_URL', 'ACTIONS_RESULTS_URL']) {
-            core.exportVariable(v, process.env[v] || '')
-          }
     - name: Run make push
+      # Layer cache lives in ECR alongside the image rather than in the Actions
+      # cache. `type=gha` needs ACTIONS_RUNTIME_TOKEN, which the runner only
+      # hands to JS actions and deliberately withholds from `run:` steps, so a
+      # bare `docker buildx build` in the Makefile can't reach it without
+      # re-exporting the runner's internals. Registry cache authenticates with
+      # the ECR login the push already does, so CI and local stay one build
+      # definition with nothing smuggled between them.
+      # image-manifest/oci-mediatypes are required: ECR rejects buildx's
+      # default cache manifest format.
+      # All branches share one :buildcache tag. Unlike the Actions cache it
+      # isn't scoped per branch, but the layers worth reusing (apt, poetry
+      # install) are the same everywhere, and a stale write is just a miss.
       run: |
         cd py-endgame-aws
         echo '${{ secrets.BATCH_CORE_CONFIG }}' > config.json
         make push TAG=${GITHUB_SHA::7} \
-          CACHE_FLAGS="--cache-from type=gha --cache-to type=gha,mode=max"
+          CACHE_FLAGS="--cache-from type=registry,ref=${IMAGE_URL}:buildcache \
+            --cache-to type=registry,ref=${IMAGE_URL}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true"

--- a/py-endgame-aws/Makefile
+++ b/py-endgame-aws/Makefile
@@ -18,18 +18,24 @@ IS_MAIN := $(shell git rev-parse --abbrev-ref HEAD | grep -q ^main$$ && echo tru
 # layer cache already does the job.
 CACHE_FLAGS ?=
 
+# Everything about the build that doesn't depend on where the result goes.
+# `build` and `push` differ only in their output flag, so they stay one build
+# definition -- tagging included, rather than a follow-up `docker tag`.
+BUILD_FLAGS := --target runtime -f .devcontainer/Dockerfile -t ${IMAGE_URL}:${TAG}
+ifeq ($(IS_MAIN),true)
+BUILD_FLAGS += -t ${IMAGE_URL}:latest
+endif
+
 build:
-	docker buildx build ${CACHE_FLAGS} --target runtime --load \
-		-f .devcontainer/Dockerfile -t ${IMAGE_URL}:${TAG} .
-	@if [ "${IS_MAIN}" = "true" ]; then \
-		docker tag ${IMAGE_URL}:${TAG} ${IMAGE_URL}:latest; \
-	fi
+	docker buildx build ${CACHE_FLAGS} ${BUILD_FLAGS} --load .
 
 _ecr_login:
 	aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com
 
-push: build _ecr_login
-	docker push ${IMAGE_URL}:${TAG}
-	@if [ "${IS_MAIN}" = "true" ]; then \
-		docker push ${IMAGE_URL}:latest; \
-	fi
+# `--push` uploads straight from the builder. Going through `build` would mean
+# `--load`ing the image into the local daemon first -- a full tarball export
+# and re-import (~35s in CI) whose only purpose was to give `docker push`
+# something to read. Needs the ECR login first, both for the push itself and
+# for the registry cache CI passes in CACHE_FLAGS.
+push: _ecr_login
+	docker buildx build ${CACHE_FLAGS} ${BUILD_FLAGS} --push .


### PR DESCRIPTION
Fixes `make push`, which has been red since the build optimization landed.

## What was actually failing

The image built fine on every attempt. Only the cache export failed:

```
#14 importing to docker ... DONE 14.7s
#13 exporting to docker image format ... DONE 19.9s

#15 exporting to GitHub Actions Cache
#15 preparing build cache for export done
#15 sending cache export done
#15 ERROR: failed to parse error response 400: <h2>Our services aren't available
    right now</h2>... invalid character '<' looking for beginning of value
```

buildkit got an HTML error page from an Azure edge where it expected JSON. A cache-export failure is fatal by default, so it took a fully successful build down with it — five times, over ~80 minutes.

## Why it's structural, not a blip

`--cache-to type=gha` needs `ACTIONS_RUNTIME_TOKEN`. The runner injects that (and the cache URLs) into **JS actions only**, and deliberately withholds it from `run:` steps — it's a privileged, short-lived credential, not an oversight. A bare `docker buildx build` inside a Makefile therefore can't reach the Actions cache at all without re-exporting the runner's internals, which is what the `actions/github-script` step was doing.

That got close but not all the way: the three copied variables aren't the whole contract the cache client reads. The log confirms both endpoints were exported —

```
ACTIONS_CACHE_URL:   https://artifactcache.actions.githubusercontent.com/...   ← legacy v1
ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/  ← v2
```

— but nothing carried over the flag that selects between them, and the legacy service is what returns an Azure "services aren't available" page rather than a real API error.

The supported fix for `type=gha` is `docker/build-push-action` (a JS action, so it gets the variables natively). That would mean CI and local no longer share one build definition, which the Makefile comment calls out as deliberate.

## What this does instead

**Registry cache in ECR.** It authenticates with the ECR login the push already does, so nothing has to be smuggled from the runner into the shell, and the Makefile stays the single build definition:

```
--cache-from type=registry,ref=${IMAGE_URL}:buildcache
--cache-to   type=registry,ref=${IMAGE_URL}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
```

`image-manifest`/`oci-mediatypes` are required — ECR rejects buildx's default cache manifest format. The `actions/github-script` step is gone.

One behavior difference worth knowing: all branches share one `:buildcache` tag, where the Actions cache was scoped per branch. The layers worth reusing (apt, `poetry install`) are the same everywhere and a stale write is just a miss, so this is a fair trade — but it does mean a branch can overwrite main's cache.

**`--push` instead of `--load` + `docker push`.** `push` now uploads straight from the builder. The old path built, exported the whole image as a tarball, re-imported it into the local daemon, then pushed — 19.9s "sending tarball" plus 14.7s "loading layer" in the last run, purely so `docker push` had something to read. `build` keeps `--load`, since a local build does want the image in the daemon.

**Tagging moved into shared `BUILD_FLAGS`** via make's own `ifeq`, so `build` and `push` differ only in their output flag. Side benefit: it drops two `@if [ "${IS_MAIN}" = "true" ]` shell conditionals that could never have worked on Windows, where this Makefile sets `SHELL := powershell.exe`.

## Verification

No Docker daemon in my sandbox, so this is **not** verified against a real build — the ECR cache round trip and the `--push` path will get their first real exercise on this PR's own CI run. What I did check:

`make -n` expands correctly in each case:

| invocation | result |
| --- | --- |
| `build` | `docker buildx build --target runtime -f .devcontainer/Dockerfile -t IMG:abc1234 --load .` |
| `build IS_MAIN=true` | same, plus `-t IMG:latest` |
| `push` | `aws ecr get-login-password ... \| docker login ...` **then** `docker buildx build <cache flags> ... --push .` |
| `push IS_MAIN=true` | same, plus `-t IMG:latest` |

Login now correctly precedes the build (it was `push: build _ecr_login`, i.e. after), which registry cache requires for both read and write. The multi-line `CACHE_FLAGS` string in the workflow resolves to exactly 4 shell words. Workflow YAML parses, and the `make-push` steps are now checkout → setup-buildx → run.

The `lint` job is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJXZ2asW38Hmx3tPwFd2PA)_