### PR TITLE
Create this repo's own CI OIDC roles

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,80 @@
+# jobs
+
+Terraform for the scheduled pulls: a Batch job definition and an EventBridge
+schedule per league, the IAM they need, and SNS failure notifications.
+
+The job queue and the data bucket aren't declared here. They belong to the
+shared Batch stack ([aws-batch-optimization][abo]) and are read out of its
+state with a `terraform_remote_state` data source, so a rename over there fails
+this plan rather than an 8am job.
+
+[abo]: https://github.com/NathanDeMaria/aws-batch-optimization/tree/main/infra
+
+## CI
+
+`terraform` runs in GitHub Actions ([`.github/workflows/terraform.yml`][wf]),
+the same pattern as [invisible-string][is] and the Batch stack:
+
+| Job | When | Credentials |
+| --- | --- | --- |
+| `lint` | every push and PR touching `jobs/**` | none |
+| `plan` | every branch and PR except main | `AWS_PLAN_ROLE_ARN` |
+| `apply` | push to main | `AWS_APPLY_ROLE_ARN` |
+
+[wf]: ../.github/workflows/terraform.yml
+[is]: https://github.com/NathanDeMaria/invisible-string/tree/main/infra
+
+### Why two roles
+
+`terraform plan` executes provider code and runs on every branch and PR. It
+must not be able to reach credentials that can change anything. So:
+
+- **plan role** — `ReadOnlyAccess`, plus write on this stack's state object and
+  its lock file. Trusts `ref:refs/heads/*` *and* `pull_request`, because a PR's
+  OIDC subject carries no ref at all — a policy trusting only refs fails on
+  every PR.
+- **apply role** — `PowerUserAccess` (everything but IAM) plus IAM scoped to
+  `endgame-*`, the prefix every role and policy here is named with. Trusts
+  `refs/heads/main` literally, so a branch named `main-hotfix` can't match.
+
+Each repo's stack creates the roles its own workflow assumes; nothing is shared
+across repos. `create_oidc_provider` defaults to **false** here, because IAM
+permits one OIDC provider per URL per account and invisible-string creates the
+one in this account.
+
+### Setup
+
+The roles are created by this stack, so the first apply is from a laptop.
+
+```bash
+make apply                 # creates endgame-ci-plan and endgame-ci-apply
+gh variable set AWS_PLAN_ROLE_ARN  --body "$(terraform output -raw ci_plan_role_arn)"
+gh variable set AWS_APPLY_ROLE_ARN --body "$(terraform output -raw ci_apply_role_arn)"
+```
+
+Repository **variables**, not secrets — a role ARN isn't secret, and the
+workflow compares them against `''` to stay dormant until they're set. Before
+that, `lint` is the only job that runs; `plan` and `apply` skip rather than
+fail red.
+
+CI also needs two repository **secrets**, which the docker workflow already
+uses: `IMAGE_URL` (the untagged ECR repository URL) and `NOTIFICATION_EMAIL`.
+
+## Local use
+
+```bash
+make plan
+make apply
+make lint         # what CI runs; no credentials needed
+```
+
+`make plan` and `make apply` read `terraform.tfvars`, which is gitignored. CI
+passes the same values as `TF_VAR_*` instead.
+
+## Bumping the season
+
+`season_year` and `wnba_season_year` in `variables.tf` are committed rather
+than derived from `timestamp()`, so the same commit plans the same way in July
+and in August. Bump `season_year` around August, when football and hockey start
+and the previous ncaabb season is long finished; `wnba_season_year` rolls over
+in the spring.

--- a/jobs/main.tf
+++ b/jobs/main.tf
@@ -153,6 +153,8 @@ data "terraform_remote_state" "batch" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 
 # ------------------------------------------------------------------------------
 # IAM Role for Scheduler

--- a/jobs/oidc.tf
+++ b/jobs/oidc.tf
@@ -1,0 +1,269 @@
+# GitHub Actions authenticates by OIDC rather than a long-lived access key.
+# Two roles, not one: `terraform plan` executes provider code and runs on every
+# branch and PR, so it must not be able to reach credentials that can apply.
+#
+# Same shape as invisible-string/infra/oidc.tf and aws-batch-optimization's --
+# each stack creates and owns the roles its own workflow assumes, rather than
+# one repo minting roles for the others. The trust policy is per-repository, so
+# there's nothing to share and nothing to keep in sync.
+
+locals {
+  owner = split("/", var.github_repository)[0]
+  name  = split("/", var.github_repository)[1]
+
+  # The ID-qualified subject GitHub actually issues. IDs rather than names is
+  # the point of the format: a repository can be renamed, but its ID can't be
+  # taken over by someone else claiming the old name.
+  subject_repo = "repo:${local.owner}@${var.github_owner_id}/${local.name}@${var.github_repository_id}"
+
+  # Kept alongside it so the policy still works if an account is ever issuing
+  # the older name-only subjects. Both forms are exact, so listing both widens
+  # nothing -- GitHub signs the claim, it can't be spoofed.
+  subject_repo_legacy = "repo:${var.github_repository}"
+
+  # IAM permits exactly one provider per URL per account, and invisible-string
+  # creates it. So this stack expects to find it rather than making a second
+  # one, which would fail with EntityAlreadyExists.
+  oidc_provider_arn = var.create_oidc_provider ? (
+    aws_iam_openid_connect_provider.github[0].arn
+    ) : (
+    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+  )
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = []
+}
+
+# ------------------------------------------------------------------------------
+# Trust policies
+#
+# The `sub` claim's shape depends on the event, which is the easy thing to get
+# wrong: a branch push is `repo:owner/name:ref:refs/heads/<branch>`, but a pull
+# request is `repo:owner/name:pull_request` with no ref at all. A plan role
+# trusting only `ref:refs/heads/*` therefore fails on every PR.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "plan_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "${local.subject_repo}:ref:refs/heads/*",
+        "${local.subject_repo}:pull_request",
+        "${local.subject_repo_legacy}:ref:refs/heads/*",
+        "${local.subject_repo_legacy}:pull_request",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "apply_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # StringLike only because two exact alternatives are listed; neither
+    # contains a wildcard, so "main-hotfix" still cannot match. Keeping the
+    # branch segment literal is what stops any branch merely starting with
+    # "main" from gaining apply rights.
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "${local.subject_repo}:ref:refs/heads/main",
+        "${local.subject_repo_legacy}:ref:refs/heads/main",
+      ]
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Plan role: read everything, write nothing except the state lock.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "ci_plan" {
+  name               = "${var.resource_name_prefix}-ci-plan"
+  description        = "terraform plan from any branch or PR of ${var.github_repository}"
+  assume_role_policy = data.aws_iam_policy_document.plan_assume_role.json
+}
+
+# ReadOnlyAccess is also what lets the `terraform_remote_state` data source in
+# main.tf read the Batch stack's state object -- a data source read takes no
+# lock, so plain s3:GetObject covers it and no extra grant is needed.
+resource "aws_iam_role_policy_attachment" "ci_plan_readonly" {
+  role       = aws_iam_role.ci_plan.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/ReadOnlyAccess"
+}
+
+# Plan reads state and takes the lock, so it needs writes on the lock object
+# even though it changes no infrastructure. Scoped to this stack's key: the
+# Batch stack's state is readable (above) but not writable from here.
+data "aws_iam_policy_document" "terraform_state" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.state_bucket}"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.state_bucket}/${var.state_key_prefix}*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "terraform_state" {
+  name        = "${var.resource_name_prefix}-terraform-state"
+  description = "Read/write this stack's terraform state and its lock file"
+  policy      = data.aws_iam_policy_document.terraform_state.json
+}
+
+resource "aws_iam_role_policy_attachment" "ci_plan_state" {
+  role       = aws_iam_role.ci_plan.name
+  policy_arn = aws_iam_policy.terraform_state.arn
+}
+
+# ------------------------------------------------------------------------------
+# Apply role: main only.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "ci_apply" {
+  name               = "${var.resource_name_prefix}-ci-apply"
+  description        = "terraform apply from main of ${var.github_repository}"
+  assume_role_policy = data.aws_iam_policy_document.apply_assume_role.json
+}
+
+# PowerUserAccess covers Batch, EventBridge Scheduler, SNS and S3, and
+# explicitly denies IAM. The IAM this stack does need is added below, scoped by
+# name prefix, rather than by attaching IAMFullAccess.
+resource "aws_iam_role_policy_attachment" "ci_apply_poweruser" {
+  role       = aws_iam_role.ci_apply.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/PowerUserAccess"
+}
+
+data "aws_iam_policy_document" "ci_apply_iam" {
+  # Every role and policy this stack creates is named `endgame-*` -- the two
+  # Batch roles, the scheduler role, and these two CI roles themselves. Keeping
+  # the grant to that prefix is what stops a compromised workflow from minting
+  # itself an admin role. The Batch job definitions and schedules are named
+  # `daily-games-*` / `odds-*`, but those aren't IAM, so PowerUserAccess covers
+  # them without a name pattern.
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:GetRole",
+      "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:ListRoleTags",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:UpdateAssumeRolePolicy",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${var.resource_name_prefix}-*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:GetPolicy",
+      "iam:ListPolicyVersions",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicyVersion",
+      "iam:GetPolicyVersion",
+      "iam:TagPolicy",
+      "iam:UntagPolicy",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.resource_name_prefix}-*",
+    ]
+  }
+
+  # Batch hands the execution and job roles to the container at submit time,
+  # and EventBridge Scheduler is handed its own role when a schedule is
+  # created, so both need PassRole.
+  statement {
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${var.resource_name_prefix}-*",
+    ]
+  }
+
+  # Reading any role is needed for plan-time refresh of things this stack
+  # references but doesn't own.
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:ListRoles",
+      "iam:ListPolicies",
+      "iam:GetOpenIDConnectProvider",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ci_apply_iam" {
+  name        = "${var.resource_name_prefix}-ci-apply-iam"
+  description = "IAM management scoped to ${var.resource_name_prefix}-* roles and policies"
+  policy      = data.aws_iam_policy_document.ci_apply_iam.json
+}
+
+resource "aws_iam_role_policy_attachment" "ci_apply_iam" {
+  role       = aws_iam_role.ci_apply.name
+  policy_arn = aws_iam_policy.ci_apply_iam.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ci_apply_state" {
+  role       = aws_iam_role.ci_apply.name
+  policy_arn = aws_iam_policy.terraform_state.arn
+}

--- a/jobs/outputs.tf
+++ b/jobs/outputs.tf
@@ -1,0 +1,16 @@
+# Set these as GitHub Actions repository *variables* (not secrets -- a role ARN
+# isn't secret, and terraform.yml compares them against '' to stay dormant
+# until they exist):
+#
+#   gh variable set AWS_PLAN_ROLE_ARN  --body "$(terraform output -raw ci_plan_role_arn)"
+#   gh variable set AWS_APPLY_ROLE_ARN --body "$(terraform output -raw ci_apply_role_arn)"
+
+output "ci_plan_role_arn" {
+  description = "role-to-assume for plan jobs (any branch, any PR)"
+  value       = aws_iam_role.ci_plan.arn
+}
+
+output "ci_apply_role_arn" {
+  description = "role-to-assume for apply jobs (main only)"
+  value       = aws_iam_role.ci_apply.arn
+}

--- a/jobs/variables.tf
+++ b/jobs/variables.tf
@@ -57,3 +57,71 @@ variable "notification_email" {
   description = "Email address to receive notifications when the job fails"
   type        = string
 }
+
+# ------------------------------------------------------------------------------
+# CI OIDC roles (oidc.tf)
+# ------------------------------------------------------------------------------
+
+variable "github_repository" {
+  description = "owner/repo allowed to assume the CI roles"
+  type        = string
+  default     = "NathanDeMaria/EndGame"
+}
+
+variable "github_owner_id" {
+  description = <<-EOT
+    Numeric ID of the GitHub account owning the repository.
+
+    GitHub issues OIDC subjects in an immutable, ID-qualified form --
+    `repo:OWNER@OWNER_ID/REPO@REPO_ID:...` -- rather than by name, so the trust
+    policy has to match on IDs. Matching on names alone silently never matches
+    and every assume fails with a generic "Not authorized".
+
+      gh api users/NathanDeMaria --jq .id
+  EOT
+  type        = number
+  default     = 5595197
+}
+
+variable "github_repository_id" {
+  description = <<-EOT
+    Numeric ID of the repository. See github_owner_id.
+
+      gh api repos/NathanDeMaria/EndGame --jq .id
+  EOT
+  type        = number
+  default     = 125161304
+}
+
+variable "create_oidc_provider" {
+  description = <<-EOT
+    Create the GitHub Actions OIDC provider. Defaults false, like
+    aws-batch-optimization: IAM permits exactly one provider per URL per
+    account, and invisible-string creates the one in this account. If this
+    account ever has none, set this true here and false there.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "state_bucket" {
+  description = "Bucket holding terraform state. Plan needs write access for the lock file."
+  type        = string
+  default     = "nathan-terraform"
+}
+
+variable "state_key_prefix" {
+  description = <<-EOT
+    Key prefix within the state bucket that CI may lock and write. Matches the
+    `key` in versions.tf; the trailing `*` in the policy covers the `.tflock`
+    object `use_lockfile` writes beside it.
+  EOT
+  type        = string
+  default     = "jobs/terraform.tfstate"
+}
+
+variable "resource_name_prefix" {
+  description = "Prefix for the IAM this stack creates. Scopes the apply role's IAM permissions."
+  type        = string
+  default     = "endgame"
+}


### PR DESCRIPTION
The terraform workflow has been dormant since it merged. `plan` and `apply`
both gate on `vars.AWS_*_ROLE_ARN != ''`, and there were no ARNs to set,
because no role in the account trusts `NathanDeMaria/EndGame`. Run
[32800472061](https://github.com/NathanDeMaria/EndGame/actions/runs/32800472061)
on main is what that looks like: `lint` green, `plan` and `apply` skipped.

This follows [invisible-string][is] and [aws-batch-optimization][abo] rather
than trying to share their roles: each stack creates the two roles its own
workflow assumes. The trust policy is per-repository and the permissions are
scoped to what the stack owns, so there's nothing to share and nothing to keep
in sync. Reusing `batch-ci-apply` would have meant one role that can rewrite
the shared Batch infrastructure from this repo's workflow.

[is]: https://github.com/NathanDeMaria/invisible-string/tree/main/infra
[abo]: https://github.com/NathanDeMaria/aws-batch-optimization/tree/main/infra

## Changes

- **`jobs/oidc.tf`** (new) — the trust policy documents and both roles.
- **`jobs/outputs.tf`** (new) — `ci_plan_role_arn` and `ci_apply_role_arn`.
- **`jobs/variables.tf`** — `github_repository`, `github_owner_id`,
  `github_repository_id`, `create_oidc_provider`, `state_bucket`,
  `state_key_prefix`, `resource_name_prefix`.
- **`jobs/main.tf`** — added `data "aws_partition" "current"`.
- **`jobs/README.md`** (new) — the CI table, why two roles, and the bootstrap.

## Scoping

- **plan** — `ReadOnlyAccess`, plus write on `nathan-terraform/jobs/terraform.tfstate*`
  for the state object and its lock. Trusts `ref:refs/heads/*` *and*
  `pull_request`, since a PR's OIDC subject carries no ref at all.

  `ReadOnlyAccess` is also what covers the `terraform_remote_state` read of the
  Batch stack's state that landed in #54 — a data source read takes no lock, so
  plain `s3:GetObject` is enough and no grant on `batch-state` is added here.

- **apply** — `PowerUserAccess` (everything but IAM) plus IAM scoped to
  `endgame-*`, the prefix every role and policy in this stack already uses. The
  Batch job definitions and schedules are named `daily-games-*` / `odds-*`, but
  those aren't IAM, so `PowerUserAccess` covers them without a name pattern.
  Trusts `refs/heads/main` literally, so a branch named `main-hotfix` can't
  match.

`create_oidc_provider` defaults to **false**. IAM permits exactly one provider
per URL per account and invisible-string creates the one in this account.

## Bootstrap

The roles are created by this stack, so the first apply is from a laptop:

```bash
cd jobs && make apply
gh variable set AWS_PLAN_ROLE_ARN  --body "$(terraform output -raw ci_plan_role_arn)"
gh variable set AWS_APPLY_ROLE_ARN --body "$(terraform output -raw ci_apply_role_arn)"
```

Repository **variables**, not secrets. The apply role's IAM grant covers
`endgame-ci-*` itself, so after that one local apply, CI maintains its own
roles.

## Verification

`terraform fmt -check -recursive` and `terraform validate` both pass on the
real config. `registry.terraform.io` is blocked from this environment, so init
ran against a local plugin mirror built from `releases.hashicorp.com`
(terraform 1.15.8, hashicorp/aws 6.27.0 — the version already in
`.terraform.lock.hcl`, which is unchanged).

A plan against live AWS isn't possible from here, so the ID-qualified subject
strings are unproven until the first apply. If they're wrong the symptom is a
generic "Not authorized" on `sts:AssumeRoleWithWebIdentity` rather than
anything more specific.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AHxHLGexxJV68v8TRZ42XD)_