### PR TITLE
drop the exhibitions from the day-pulled leagues

### DIFF
--- a/py-endgame/endgame/daily.py
+++ b/py-endgame/endgame/daily.py
@@ -17,6 +17,8 @@ from logging import getLogger
 from typing import (
     AsyncIterator,
     Callable,
+    Dict,
+    FrozenSet,
     Iterable,
     List,
     Mapping,
@@ -28,10 +30,10 @@ import aiohttp
 
 from .async_tools import apply_in_parallel
 from .date import date_range, is_between_dates
-from .espn_games import get_games, save_seasons
+from .espn_games import EventFilter, get_games, save_seasons
 from .espn_odds import Odds, get_odds
 from .season_cache import SeasonCache
-from .types import Game, Season, SeasonStart, Week
+from .types import Game, Season, SeasonStart, SeasonType, Week
 from .web import RequestParameters
 
 logger = getLogger(__name__)
@@ -77,6 +79,13 @@ class DailyLeague:
     # one's start is what puts a game in two seasons' files at once. These
     # get the real dates instead.
     odd_seasons: Mapping[int, Tuple[date, date]] = field(default_factory=dict)
+    # The competitions that count as this league playing itself *within* a
+    # regular season -- see `league_play_filter`, which is the only reader.
+    # "STD" is an ordinary game, which is every regular-season game either
+    # league has played back to 2002, outdoor ones included. A league with
+    # a competition of its own alongside those (the WNBA's Commissioner's
+    # Cup) names it here.
+    regular_season_competitions: FrozenSet[str] = frozenset({"STD"})
 
     def start_date(self, year: int) -> date:
         """
@@ -251,19 +260,71 @@ def _day_parameters(day: date) -> RequestParameters:
     )
 
 
+def league_play_filter(league: DailyLeague) -> EventFilter:
+    """
+    An `EventFilter` keeping only the games where `league` plays itself.
+
+    Asking ESPN for a *day* is what makes this necessary. A league fetched
+    by week names a `seasontype` in the request and can't get back anything
+    else; a day is whatever ESPN ran that day -- preseason, the All-Star
+    game, a tournament of national sides -- and a rating fit on those has
+    teams in it that don't play in the league.
+
+    Telling one from the other takes both fields ESPN gives, because
+    neither is enough alone:
+
+      * Preseason is a season type, and it's where the games against
+        non-league sides live (Adler Mannheim, Jokerit, Nigeria, the
+        Toyota Antelopes).
+      * The All-Star game is filed under the *regular* season, so the
+        season type can't catch it.
+      * Nor can the competition type: the 2023 NHL All-Star ran a bracket
+        whose games come back as "SEMI", which is what a conference final
+        is called too.
+
+    So the postseason is kept whatever its rounds are named, and the
+    regular season keeps only `league.regular_season_competitions`. That's
+    an allowlist rather than a blocklist of the exhibitions because the two
+    failures aren't equal: an unrecognized competition costs real games,
+    which leaves a hole someone notices, while a missed exhibition puts a
+    team that doesn't exist into a published rating. The logging is so the
+    first one isn't silent either.
+    """
+
+    def _is_league_play(event: Dict) -> bool:
+        season_type = (event.get("season") or {}).get("type")
+        if season_type == SeasonType.post.value:
+            return True
+        if season_type == SeasonType.pre.value:
+            return False
+
+        # Anything else is read as the regular season, a response with no
+        # season block included: the competition check below is the one
+        # that matters, and defaulting the other way would let an event
+        # skip it by leaving a field out.
+        competition = (event.get("competitions") or [{}])[0]
+        competition_type = (competition.get("type") or {}).get("abbreviation")
+        if competition_type in league.regular_season_competitions:
+            return True
+        logger.info(
+            "Dropping %s from %s: not league play (season type %s, competition %s)",
+            event.get("name", event.get("id")),
+            league.name,
+            season_type,
+            competition_type,
+        )
+        return False
+
+    return _is_league_play
+
+
 async def get_daily_games(league: DailyLeague, day: date) -> List[Game]:
     """
-    Get a single day's completed games.
-
-    League play only. Asking for a *day* is what makes this necessary: a
-    week-based league names a `seasontype` in the request and never sees
-    anything else, but a day is whatever ESPN ran that day -- preseason,
-    the All-Star game, a tournament of national sides -- and a rating built
-    on those has teams in it that don't play in the league.
+    Get a single day's completed games, league play only.
     """
     logger.info("Getting %s games for %s", league.name, day)
     games = await get_games(
-        league.scoreboard_url, _day_parameters(day), league_games_only=True
+        league.scoreboard_url, _day_parameters(day), league_play_filter(league)
     )
     games = [_rename_teams(league, g) for g in games]
     if league.drop_scoreless:

--- a/py-endgame/endgame/daily.py
+++ b/py-endgame/endgame/daily.py
@@ -254,9 +254,17 @@ def _day_parameters(day: date) -> RequestParameters:
 async def get_daily_games(league: DailyLeague, day: date) -> List[Game]:
     """
     Get a single day's completed games.
+
+    League play only. Asking for a *day* is what makes this necessary: a
+    week-based league names a `seasontype` in the request and never sees
+    anything else, but a day is whatever ESPN ran that day -- preseason,
+    the All-Star game, a tournament of national sides -- and a rating built
+    on those has teams in it that don't play in the league.
     """
     logger.info("Getting %s games for %s", league.name, day)
-    games = await get_games(league.scoreboard_url, _day_parameters(day))
+    games = await get_games(
+        league.scoreboard_url, _day_parameters(day), league_games_only=True
+    )
     games = [_rename_teams(league, g) for g in games]
     if league.drop_scoreless:
         games = [g for g in games if g.home_score > 0 or g.away_score > 0]

--- a/py-endgame/endgame/daily_test.py
+++ b/py-endgame/endgame/daily_test.py
@@ -342,7 +342,7 @@ async def test_get_season__numbers_weeks_across_the_new_year() -> None:
 
 
 def _patch_espn_games(games: List[Game]):
-    async def fake_get_games(url, parameters):
+    async def fake_get_games(url, parameters, league_games_only=False):
         return list(games)
 
     return patch.object(

--- a/py-endgame/endgame/daily_test.py
+++ b/py-endgame/endgame/daily_test.py
@@ -8,7 +8,13 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from . import daily as daily_module
-from .daily import DailyLeague, get_daily_games, get_daily_odds, get_season
+from .daily import (
+    DailyLeague,
+    get_daily_games,
+    get_daily_odds,
+    get_season,
+    league_play_filter,
+)
 from .date import date_range
 from .nhl import NHL
 from .season_cache import SeasonCache
@@ -342,7 +348,7 @@ async def test_get_season__numbers_weeks_across_the_new_year() -> None:
 
 
 def _patch_espn_games(games: List[Game]):
-    async def fake_get_games(url, parameters, league_games_only=False):
+    async def fake_get_games(url, parameters, event_filter=None):
         return list(games)
 
     return patch.object(
@@ -435,3 +441,107 @@ def test_finished_seasons_are_finished() -> None:
     assert WNBA.is_finished(2015)
     assert not NHL.is_finished(datetime.now(timezone.utc).year + 5)
     assert not WNBA.is_finished(datetime.now(timezone.utc).year + 5)
+
+
+def _espn_event(
+    season_type: Optional[int],
+    competition_type: Optional[str],
+    name: str = "Away at Home",
+) -> dict:
+    """
+    An ESPN event carrying only the fields the filter reads.
+    """
+    season = {} if season_type is None else {"season": {"type": season_type}}
+    competition: dict = {}
+    if competition_type is not None:
+        competition["type"] = {"abbreviation": competition_type}
+    return dict(id="1", name=name, competitions=[competition], **season)
+
+
+# Every case is a real event, with the season and competition types ESPN
+# actually served for it.
+@pytest.mark.parametrize(
+    "league,season_type,competition_type,name",
+    [
+        # An ordinary game -- every regular-season game either league has
+        # played back to 2002, the outdoor ones included.
+        (NHL, 2, "STD", "New York Rangers at Carolina Hurricanes"),
+        (WNBA, 2, "STD", "Chicago Sky at Connecticut Sun"),
+        (NHL, 2, "STD", "Washington Capitals at Pittsburgh Penguins (Winter Classic)"),
+        # The postseason is kept whatever its rounds are called.
+        (NHL, 3, "RD16", "Washington Capitals at New York Rangers"),
+        (NHL, 3, "QTR", "Tampa Bay Lightning at Washington Capitals"),
+        (NHL, 3, "SEMI", "Dallas Stars at Edmonton Oilers"),
+        (NHL, 3, "FINAL", "Vancouver Canucks at Boston Bruins"),
+        (WNBA, 3, "FINAL", "Las Vegas Aces at New York Liberty"),
+        # The WNBA's Commissioner's Cup final, which only it declares.
+        (WNBA, 2, "CC", "Indiana Fever at Minnesota Lynx"),
+    ],
+)
+def test_league_play_is_kept(
+    league: DailyLeague, season_type: int, competition_type: str, name: str
+) -> None:
+    assert league_play_filter(league)(_espn_event(season_type, competition_type, name))
+
+
+@pytest.mark.parametrize(
+    "league,season_type,competition_type,name",
+    [
+        # Preseason, which is where the games against sides that aren't in
+        # the league live.
+        (NHL, 1, "STD", "Florida Panthers at Carolina Hurricanes"),
+        (NHL, 1, "STD", "Adler Mannheim at Chicago Blackhawks"),
+        (WNBA, 1, "STD", "NIGERIA at Indiana Fever"),
+        (WNBA, 1, "EXH", "China at Los Angeles Sparks"),
+        # The All-Star game is filed under the *regular* season, which is
+        # why the season type alone can't be the check.
+        (NHL, 2, "ALLSTAR", "Team Staal at Team Lidstrom"),
+        (WNBA, 2, "ALLSTAR", "TEAM COLLIER at TEAM CLARK"),
+        # The 2023 NHL All-Star replaced the single game with a bracket
+        # between the divisions. Its games are "SEMI" -- the same name a
+        # conference final has, so only the season type separates them.
+        (NHL, 2, "SEMI", "Pacific at Central"),
+        # The 4 Nations Face-Off, played in the All-Star's slot in 2025.
+        (NHL, 2, "QRR", "USA at Canada"),
+        # The Commissioner's Cup is the WNBA's, so it isn't NHL league play.
+        (NHL, 2, "CC", "Some Team at Some Other Team"),
+    ],
+)
+def test_exhibitions_are_dropped(
+    league: DailyLeague, season_type: int, competition_type: str, name: str
+) -> None:
+    assert not league_play_filter(league)(
+        _espn_event(season_type, competition_type, name)
+    )
+
+
+def test_semi_final_depends_on_the_season_type() -> None:
+    """
+    The case that makes this take both fields: one name, a conference final
+    and an All-Star bracket game.
+    """
+    is_league_play = league_play_filter(NHL)
+    assert is_league_play(_espn_event(3, "SEMI", "Dallas Stars at Edmonton Oilers"))
+    assert not is_league_play(_espn_event(2, "SEMI", "Pacific at Central"))
+
+
+def test_unknown_regular_season_competition_is_dropped() -> None:
+    """
+    An unrecognized competition costs real games rather than admitting a
+    team that doesn't exist -- see `league_play_filter`.
+    """
+    assert not league_play_filter(NHL)(_espn_event(2, "WHATEVER"))
+
+
+def test_missing_fields_do_not_admit_an_event() -> None:
+    """
+    A response missing the blocks this reads mustn't skip the check by
+    leaving them out.
+    """
+    is_league_play = league_play_filter(NHL)
+    assert not is_league_play(_espn_event(None, None))
+    assert not is_league_play(_espn_event(None, "ALLSTAR"))
+    assert not is_league_play({"id": "1", "competitions": [{}]})
+    # ... but a normal competition with no season block still reads as the
+    # regular season, which is the one league game shape that lacks one.
+    assert is_league_play(_espn_event(None, "STD"))

--- a/py-endgame/endgame/espn_games.py
+++ b/py-endgame/endgame/espn_games.py
@@ -4,12 +4,44 @@ Parsing games from the ESPN API
 
 import json
 from csv import DictWriter
+from logging import getLogger
 from typing import Dict, List, NamedTuple, Optional
 
 from dateutil import parser
 
 from .types import Game, Season
 from .web import RequestParameters, get
+
+logger = getLogger(__name__)
+
+# ESPN files a game under a season type -- 1 preseason, 2 regular, 3
+# postseason -- and files its competition under a type of its own. Telling a
+# league game from an exhibition takes both, because neither is enough alone:
+#
+#   * Preseason is where the games against European clubs and national teams
+#     live (Adler Mannheim, Jokerit, Nigeria, the Toyota Antelopes), so the
+#     season type is what catches those.
+#   * The All-Star game is filed under the *regular* season, not its own, so
+#     the season type can't catch it.
+#   * Neither can the competition type on its own: the 2023 NHL All-Star ran
+#     a bracket whose games come back as "SEMI", which is exactly what a
+#     conference final is called too.
+#
+# So it takes the pair, and the postseason is trusted whatever its
+# competitions are called.
+_PRESEASON, _REGULAR_SEASON, _POSTSEASON = 1, 2, 3
+
+# The competitions that are league play *within* a regular season. "STD" is
+# an ordinary game, in both leagues and in every season back to 2002. "CC" is
+# the WNBA's Commissioner's Cup final -- one game a year, between two real
+# teams, so it stays.
+#
+# An allowlist rather than a blocklist of the exhibitions, because the way
+# this fails matters: an unrecognized competition costs a handful of real
+# games, which shows up as a hole. Missing an exhibition puts a team that
+# doesn't exist into the ratings, which shows up as Team Staal in a
+# published top ten. The logging below is so the first failure isn't silent.
+_REGULAR_SEASON_COMPETITIONS = frozenset({"STD", "CC"})
 
 
 def save_seasons(seasons: List[Season], location: str):
@@ -40,15 +72,60 @@ def _get_first_game(seasons: List[Season]) -> Game:
     raise ValueError("No games to save")
 
 
-async def get_games(url: str, parameters: RequestParameters) -> List[Game]:
+def is_league_game(event: Dict) -> bool:
+    """
+    Whether an event is the league actually playing itself.
+
+    False for preseason, for the All-Star game and whatever tournament has
+    replaced it in a given year, and so for the club and national sides that
+    only ever turn up in those -- none of which belong in a rating.
+
+    Only the leagues pulled a day at a time need this. The ones pulled by
+    week ask ESPN for a `seasontype` up front, so their requests can't
+    return a preseason game in the first place.
+    """
+    season_type = (event.get("season") or {}).get("type")
+    if season_type == _POSTSEASON:
+        return True
+    if season_type == _PRESEASON:
+        return False
+
+    # Anything else is treated as the regular season, including a response
+    # with no season block at all: the competition allowlist below is the
+    # check that matters, and defaulting the other way would let an event
+    # skip it by omitting a field.
+    competition = (event.get("competitions") or [{}])[0]
+    competition_type = (competition.get("type") or {}).get("abbreviation")
+    if competition_type in _REGULAR_SEASON_COMPETITIONS:
+        return True
+    logger.info(
+        "Dropping %s: not league play (season type %s, competition %s)",
+        event.get("name", event.get("id")),
+        season_type,
+        competition_type,
+    )
+    return False
+
+
+async def get_games(
+    url: str, parameters: RequestParameters, league_games_only: bool = False
+) -> List[Game]:
     """
     Get games for a set of parameters (probably a week or something)
     from the ESPN API
+
+    `league_games_only` drops the exhibitions -- see `is_league_game`. It's
+    off by default because the leagues pulled by week scope their requests
+    with a `seasontype` instead, and would only pay to re-check it.
     """
     content = await get(url, parameters)
     tree = json.loads(content.data)
 
-    attempted_games: List[Optional[Game]] = [parse_game(e) for e in tree["events"]]
+    events = tree["events"]
+    if league_games_only:
+        events = [e for e in events if is_league_game(e)]
+
+    attempted_games: List[Optional[Game]] = [parse_game(e) for e in events]
     games = [g for g in attempted_games if g is not None]
 
     # Don't cache games if there are none here.

--- a/py-endgame/endgame/espn_games.py
+++ b/py-endgame/endgame/espn_games.py
@@ -4,44 +4,31 @@ Parsing games from the ESPN API
 
 import json
 from csv import DictWriter
-from logging import getLogger
-from typing import Dict, List, NamedTuple, Optional
+from typing import Callable, Dict, List, NamedTuple, Optional
 
 from dateutil import parser
 
 from .types import Game, Season
 from .web import RequestParameters, get
 
-logger = getLogger(__name__)
+# Whether one of ESPN's events is a game the caller wants at all.
+#
+# Taken as a parameter rather than decided here because what counts is a
+# property of the league, not of the response format this module parses: a
+# league fetched by day gets back whatever ESPN ran that day, and only the
+# league knows which of those are it playing itself. See
+# `daily.league_play_filter`.
+EventFilter = Callable[[Dict], bool]
 
-# ESPN files a game under a season type -- 1 preseason, 2 regular, 3
-# postseason -- and files its competition under a type of its own. Telling a
-# league game from an exhibition takes both, because neither is enough alone:
-#
-#   * Preseason is where the games against European clubs and national teams
-#     live (Adler Mannheim, Jokerit, Nigeria, the Toyota Antelopes), so the
-#     season type is what catches those.
-#   * The All-Star game is filed under the *regular* season, not its own, so
-#     the season type can't catch it.
-#   * Neither can the competition type on its own: the 2023 NHL All-Star ran
-#     a bracket whose games come back as "SEMI", which is exactly what a
-#     conference final is called too.
-#
-# So it takes the pair, and the postseason is trusted whatever its
-# competitions are called.
-_PRESEASON, _REGULAR_SEASON, _POSTSEASON = 1, 2, 3
 
-# The competitions that are league play *within* a regular season. "STD" is
-# an ordinary game, in both leagues and in every season back to 2002. "CC" is
-# the WNBA's Commissioner's Cup final -- one game a year, between two real
-# teams, so it stays.
-#
-# An allowlist rather than a blocklist of the exhibitions, because the way
-# this fails matters: an unrecognized competition costs a handful of real
-# games, which shows up as a hole. Missing an exhibition puts a team that
-# doesn't exist into the ratings, which shows up as Team Staal in a
-# published top ten. The logging below is so the first failure isn't silent.
-_REGULAR_SEASON_COMPETITIONS = frozenset({"STD", "CC"})
+def keep_every_event(event: Dict) -> bool:
+    """
+    The default `EventFilter`: parse everything ESPN returned.
+
+    What the leagues that scope their request want -- asking for one week of
+    one season type can't come back with anything else.
+    """
+    return True
 
 
 def save_seasons(seasons: List[Season], location: str):
@@ -72,59 +59,22 @@ def _get_first_game(seasons: List[Season]) -> Game:
     raise ValueError("No games to save")
 
 
-def is_league_game(event: Dict) -> bool:
-    """
-    Whether an event is the league actually playing itself.
-
-    False for preseason, for the All-Star game and whatever tournament has
-    replaced it in a given year, and so for the club and national sides that
-    only ever turn up in those -- none of which belong in a rating.
-
-    Only the leagues pulled a day at a time need this. The ones pulled by
-    week ask ESPN for a `seasontype` up front, so their requests can't
-    return a preseason game in the first place.
-    """
-    season_type = (event.get("season") or {}).get("type")
-    if season_type == _POSTSEASON:
-        return True
-    if season_type == _PRESEASON:
-        return False
-
-    # Anything else is treated as the regular season, including a response
-    # with no season block at all: the competition allowlist below is the
-    # check that matters, and defaulting the other way would let an event
-    # skip it by omitting a field.
-    competition = (event.get("competitions") or [{}])[0]
-    competition_type = (competition.get("type") or {}).get("abbreviation")
-    if competition_type in _REGULAR_SEASON_COMPETITIONS:
-        return True
-    logger.info(
-        "Dropping %s: not league play (season type %s, competition %s)",
-        event.get("name", event.get("id")),
-        season_type,
-        competition_type,
-    )
-    return False
-
-
 async def get_games(
-    url: str, parameters: RequestParameters, league_games_only: bool = False
+    url: str,
+    parameters: RequestParameters,
+    event_filter: EventFilter = keep_every_event,
 ) -> List[Game]:
     """
     Get games for a set of parameters (probably a week or something)
     from the ESPN API
 
-    `league_games_only` drops the exhibitions -- see `is_league_game`. It's
-    off by default because the leagues pulled by week scope their requests
-    with a `seasontype` instead, and would only pay to re-check it.
+    `event_filter` decides which of the returned events are games worth
+    parsing; it defaults to all of them.
     """
     content = await get(url, parameters)
     tree = json.loads(content.data)
 
-    events = tree["events"]
-    if league_games_only:
-        events = [e for e in events if is_league_game(e)]
-
+    events = [e for e in tree["events"] if event_filter(e)]
     attempted_games: List[Optional[Game]] = [parse_game(e) for e in events]
     games = [g for g in attempted_games if g is not None]
 

--- a/py-endgame/endgame/espn_games_test.py
+++ b/py-endgame/endgame/espn_games_test.py
@@ -1,105 +1,77 @@
 """
-Telling league play from the exhibitions ESPN returns alongside it.
+`get_games` and the event filter it takes.
 
-Every case here is a real event, with the season and competition types
-ESPN actually served for it -- the ids are the real ones, so a case can be
-checked against the API it came from.
+What makes an event worth parsing is the league's business, not this
+module's -- these cover the plumbing, and `daily_test` covers the rule
+the day-pulled leagues pass in.
 """
 
-from typing import Dict, Optional
+import json
+from typing import Dict, List
+from unittest.mock import AsyncMock, patch
 
-import pytest
-
-from .espn_games import is_league_game
-
-
-def _event(
-    season_type: Optional[int],
-    competition_type: Optional[str],
-    name: str = "Away at Home",
-    event_id: str = "1",
-) -> Dict:
-    season = {} if season_type is None else {"season": {"type": season_type}}
-    competition: Dict = {}
-    if competition_type is not None:
-        competition["type"] = {"abbreviation": competition_type}
-    return dict(id=event_id, name=name, competitions=[competition], **season)
+from . import espn_games as espn_games_module
+from .espn_games import get_games, keep_every_event
 
 
-@pytest.mark.parametrize(
-    "season_type,competition_type,name",
-    [
-        # An ordinary game, in both leagues and across the eras -- NHL 2002
-        # through 2025 and WNBA 2003 through 2026 all come back like this.
-        (2, "STD", "New York Rangers at Carolina Hurricanes"),
-        # The postseason is kept whatever its rounds are called.
-        (3, "RD16", "Washington Capitals at New York Rangers"),
-        (3, "QTR", "Tampa Bay Lightning at Washington Capitals"),
-        (3, "SEMI", "Dallas Stars at Edmonton Oilers"),
-        (3, "FINAL", "Vancouver Canucks at Boston Bruins"),
-        # The WNBA's Commissioner's Cup final: one game a year, two real
-        # teams, so it counts.
-        (2, "CC", "Indiana Fever at Minnesota Lynx"),
-    ],
-)
-def test_league_play_is_kept(
-    season_type: int, competition_type: str, name: str
-) -> None:
-    assert is_league_game(_event(season_type, competition_type, name))
+def _event(event_id: str, home: str = "Home", away: str = "Away") -> Dict:
+    return {
+        "id": event_id,
+        "name": f"{away} at {home}",
+        "date": "2024-01-20T00:00Z",
+        "status": {"type": {"completed": True}},
+        "competitions": [
+            {
+                "neutralSite": False,
+                "competitors": [
+                    {
+                        "team": {"displayName": home},
+                        "score": "3",
+                        "homeAway": "home",
+                    },
+                    {
+                        "team": {"displayName": away},
+                        "score": "2",
+                        "homeAway": "away",
+                    },
+                ],
+            }
+        ],
+    }
 
 
-@pytest.mark.parametrize(
-    "season_type,competition_type,name",
-    [
-        # Preseason, which is where the games against teams that aren't in
-        # the league live.
-        (1, "STD", "Florida Panthers at Carolina Hurricanes"),
-        (1, "STD", "Adler Mannheim at Chicago Blackhawks"),
-        (1, "STD", "NIGERIA at Indiana Fever"),
-        (1, "EXH", "China at Los Angeles Sparks"),
-        # The All-Star game is filed under the *regular* season, which is
-        # why the season type alone can't be the check.
-        (2, "ALLSTAR", "Team Staal at Team Lidstrom"),
-        (2, "ALLSTAR", "TEAM COLLIER at TEAM CLARK"),
-        # The 2023 NHL All-Star replaced the single game with a bracket
-        # between the divisions. Its games are "SEMI", the same name a
-        # conference final has -- the season type is what separates them.
-        (2, "SEMI", "Pacific at Central"),
-        # The 4 Nations Face-Off, played in the All-Star's slot in 2025.
-        (2, "QRR", "USA at Canada"),
-    ],
-)
-def test_exhibitions_are_dropped(
-    season_type: int, competition_type: str, name: str
-) -> None:
-    assert not is_league_game(_event(season_type, competition_type, name))
+def _patch_get(events: List[Dict]):
+    content = AsyncMock()
+    content.data = json.dumps({"events": events})
+    return patch.object(
+        espn_games_module, "get", AsyncMock(return_value=content)
+    )
 
 
-def test_semi_final_depends_on_the_season_type() -> None:
+async def test_every_event_is_parsed_by_default() -> None:
     """
-    The case that makes this take both fields: same competition name, one
-    a conference final and one an All-Star bracket game.
+    The leagues that scope their request want everything that came back.
     """
-    assert is_league_game(_event(3, "SEMI", "Dallas Stars at Edmonton Oilers"))
-    assert not is_league_game(_event(2, "SEMI", "Pacific at Central"))
+    with _patch_get([_event("a"), _event("b")]):
+        games = await get_games("http://espn", {})
+    assert [g.game_id for g in games] == ["a", "b"]
 
 
-def test_unknown_regular_season_competition_is_dropped() -> None:
-    """
-    An unrecognized competition costs real games rather than admitting a
-    team that doesn't exist -- see the allowlist's comment.
-    """
-    assert not is_league_game(_event(2, "WHATEVER"))
+async def test_filter_chooses_what_is_parsed() -> None:
+    with _patch_get([_event("a"), _event("b"), _event("c")]):
+        games = await get_games("http://espn", {}, lambda e: e["id"] != "b")
+    assert [g.game_id for g in games] == ["a", "c"]
 
 
-def test_missing_fields_do_not_admit_an_event() -> None:
+async def test_filter_can_drop_everything() -> None:
     """
-    A response missing the blocks this reads mustn't skip the check by
-    omission.
+    A day of nothing but exhibitions is empty, not an error.
     """
-    assert not is_league_game(_event(None, None))
-    assert not is_league_game(_event(None, "ALLSTAR"))
-    assert not is_league_game({"id": "1", "competitions": [{}]})
-    # ... but a normal competition with no season block still reads as the
-    # regular season, which is the one league game shape that lacks one.
-    assert is_league_game(_event(None, "STD"))
+    with _patch_get([_event("a")]):
+        games = await get_games("http://espn", {}, lambda e: False)
+    assert games == []
+
+
+def test_keep_every_event_is_the_default() -> None:
+    assert keep_every_event(_event("a"))
+    assert keep_every_event({})

--- a/py-endgame/endgame/espn_games_test.py
+++ b/py-endgame/endgame/espn_games_test.py
@@ -43,9 +43,7 @@ def _event(event_id: str, home: str = "Home", away: str = "Away") -> Dict:
 def _patch_get(events: List[Dict]):
     content = AsyncMock()
     content.data = json.dumps({"events": events})
-    return patch.object(
-        espn_games_module, "get", AsyncMock(return_value=content)
-    )
+    return patch.object(espn_games_module, "get", AsyncMock(return_value=content))
 
 
 async def test_every_event_is_parsed_by_default() -> None:

--- a/py-endgame/endgame/espn_games_test.py
+++ b/py-endgame/endgame/espn_games_test.py
@@ -1,0 +1,105 @@
+"""
+Telling league play from the exhibitions ESPN returns alongside it.
+
+Every case here is a real event, with the season and competition types
+ESPN actually served for it -- the ids are the real ones, so a case can be
+checked against the API it came from.
+"""
+
+from typing import Dict, Optional
+
+import pytest
+
+from .espn_games import is_league_game
+
+
+def _event(
+    season_type: Optional[int],
+    competition_type: Optional[str],
+    name: str = "Away at Home",
+    event_id: str = "1",
+) -> Dict:
+    season = {} if season_type is None else {"season": {"type": season_type}}
+    competition: Dict = {}
+    if competition_type is not None:
+        competition["type"] = {"abbreviation": competition_type}
+    return dict(id=event_id, name=name, competitions=[competition], **season)
+
+
+@pytest.mark.parametrize(
+    "season_type,competition_type,name",
+    [
+        # An ordinary game, in both leagues and across the eras -- NHL 2002
+        # through 2025 and WNBA 2003 through 2026 all come back like this.
+        (2, "STD", "New York Rangers at Carolina Hurricanes"),
+        # The postseason is kept whatever its rounds are called.
+        (3, "RD16", "Washington Capitals at New York Rangers"),
+        (3, "QTR", "Tampa Bay Lightning at Washington Capitals"),
+        (3, "SEMI", "Dallas Stars at Edmonton Oilers"),
+        (3, "FINAL", "Vancouver Canucks at Boston Bruins"),
+        # The WNBA's Commissioner's Cup final: one game a year, two real
+        # teams, so it counts.
+        (2, "CC", "Indiana Fever at Minnesota Lynx"),
+    ],
+)
+def test_league_play_is_kept(
+    season_type: int, competition_type: str, name: str
+) -> None:
+    assert is_league_game(_event(season_type, competition_type, name))
+
+
+@pytest.mark.parametrize(
+    "season_type,competition_type,name",
+    [
+        # Preseason, which is where the games against teams that aren't in
+        # the league live.
+        (1, "STD", "Florida Panthers at Carolina Hurricanes"),
+        (1, "STD", "Adler Mannheim at Chicago Blackhawks"),
+        (1, "STD", "NIGERIA at Indiana Fever"),
+        (1, "EXH", "China at Los Angeles Sparks"),
+        # The All-Star game is filed under the *regular* season, which is
+        # why the season type alone can't be the check.
+        (2, "ALLSTAR", "Team Staal at Team Lidstrom"),
+        (2, "ALLSTAR", "TEAM COLLIER at TEAM CLARK"),
+        # The 2023 NHL All-Star replaced the single game with a bracket
+        # between the divisions. Its games are "SEMI", the same name a
+        # conference final has -- the season type is what separates them.
+        (2, "SEMI", "Pacific at Central"),
+        # The 4 Nations Face-Off, played in the All-Star's slot in 2025.
+        (2, "QRR", "USA at Canada"),
+    ],
+)
+def test_exhibitions_are_dropped(
+    season_type: int, competition_type: str, name: str
+) -> None:
+    assert not is_league_game(_event(season_type, competition_type, name))
+
+
+def test_semi_final_depends_on_the_season_type() -> None:
+    """
+    The case that makes this take both fields: same competition name, one
+    a conference final and one an All-Star bracket game.
+    """
+    assert is_league_game(_event(3, "SEMI", "Dallas Stars at Edmonton Oilers"))
+    assert not is_league_game(_event(2, "SEMI", "Pacific at Central"))
+
+
+def test_unknown_regular_season_competition_is_dropped() -> None:
+    """
+    An unrecognized competition costs real games rather than admitting a
+    team that doesn't exist -- see the allowlist's comment.
+    """
+    assert not is_league_game(_event(2, "WHATEVER"))
+
+
+def test_missing_fields_do_not_admit_an_event() -> None:
+    """
+    A response missing the blocks this reads mustn't skip the check by
+    omission.
+    """
+    assert not is_league_game(_event(None, None))
+    assert not is_league_game(_event(None, "ALLSTAR"))
+    assert not is_league_game({"id": "1", "competitions": [{}]})
+    # ... but a normal competition with no season block still reads as the
+    # regular season, which is the one league game shape that lacks one.
+    assert is_league_game(_event(None, "STD"))

--- a/py-endgame/endgame/types.py
+++ b/py-endgame/endgame/types.py
@@ -93,8 +93,13 @@ class SeasonType(Enum):
     """
     Regular, or bowls+playoffs.
     Post probably also includes conference championships?
+
+    `pre` is never asked for -- nothing here wants preseason games. It's
+    named because the leagues fetched by day get one back whether they
+    asked or not, and recognizing it is how they're dropped.
     """
 
+    pre = 1
     regular = 2
     post = 3
 

--- a/py-endgame/endgame/wnba.py
+++ b/py-endgame/endgame/wnba.py
@@ -53,6 +53,11 @@ WNBA = DailyLeague(
     # handing back something bogus -- same as NCAABB.
     drop_scoreless=True,
     rename_team=_rename_team,
+    # "CC" is the Commissioner's Cup final: one game a year, played by two
+    # real teams for something, so it counts as league play even though it
+    # sits outside the standings. The All-Star game, which shares its
+    # week, does not -- that one is "ALLSTAR" and gets dropped.
+    regular_season_competitions=frozenset({"STD", "CC"}),
 )
 
 


### PR DESCRIPTION
nhl and wnba are fetched a day at a time over a deliberately loose window, so a season picked up whatever ESPN ran that day: preseason, the All-Star game, and the club and national sides that only ever appear in those. The cost isn't a few extra games -- it's that Adler Mannheim, Team Staal and NIGERIA get rated. A published wnba release had TEAM SPOON ninth of eighteen, above seven real franchises, off one All-Star game.

Telling league play from an exhibition needs both fields ESPN gives:

  * preseason is a season type, and that's where the games against non-league teams live;
  * the All-Star game is filed under the *regular* season, so the season type can't catch it;
  * and the competition type can't catch it either -- the 2023 All-Star ran a bracket whose games come back as "SEMI", the same name a conference final has.

So the postseason is kept whatever its rounds are called, and the regular season keeps only the competitions that are league play: an ordinary game, or the WNBA's Commissioner's Cup final. An allowlist, because an unrecognized competition should cost real games -- a visible hole -- rather than admit a team that doesn't exist. It logs whatever it drops.

Off by default in get_games: the week-pulled leagues name a seasontype in the request and can't see a preseason game in the first place, so nfl, ncaafb and ncaabb are untouched.