### PR TITLE
don't die on a fixture ESPN never filled in

### DIFF
--- a/py-endgame/endgame/daily.py
+++ b/py-endgame/endgame/daily.py
@@ -86,6 +86,12 @@ class DailyLeague:
     # a competition of its own alongside those (the WNBA's Commissioner's
     # Cup) names it here.
     regular_season_competitions: FrozenSet[str] = frozenset({"STD"})
+    # Event ids for exhibitions ESPN filed as ordinary games, so nothing in
+    # the response marks them. Named one at a time because that's the only
+    # thing that separates them -- and kept rare on purpose: every id in
+    # here is a game no rule could catch, so a growing list means the rule
+    # itself has stopped working.
+    untagged_exhibitions: FrozenSet[str] = frozenset()
 
     def start_date(self, year: int) -> date:
         """
@@ -292,6 +298,9 @@ def league_play_filter(league: DailyLeague) -> EventFilter:
     """
 
     def _is_league_play(event: Dict) -> bool:
+        if event.get("id") in league.untagged_exhibitions:
+            return False
+
         season_type = (event.get("season") or {}).get("type")
         if season_type == SeasonType.post.value:
             return True

--- a/py-endgame/endgame/daily_test.py
+++ b/py-endgame/endgame/daily_test.py
@@ -545,3 +545,23 @@ def test_missing_fields_do_not_admit_an_event() -> None:
     # ... but a normal competition with no season block still reads as the
     # regular season, which is the one league game shape that lacks one.
     assert is_league_play(_espn_event(None, "STD"))
+
+
+def test_untagged_exhibitions_are_dropped_by_id() -> None:
+    """
+    The 2002 WNBA All-Star game, which ESPN filed as an ordinary game --
+    nothing in the response tells it from league play, so it's named.
+    """
+    all_star = _espn_event(2, "STD", "Western Conf West at Eastern Conf East")
+    all_star["id"] = "220715098"
+    assert not league_play_filter(WNBA)(all_star)
+
+    # The same event for a league that hasn't named it is left alone, so
+    # one league's exception can't reach another's games.
+    assert league_play_filter(NHL)(all_star)
+
+
+def test_an_ordinary_game_keeps_its_id() -> None:
+    ordinary = _espn_event(2, "STD", "Chicago Sky at Connecticut Sun")
+    ordinary["id"] = "401244567"
+    assert league_play_filter(WNBA)(ordinary)

--- a/py-endgame/endgame/espn_games.py
+++ b/py-endgame/endgame/espn_games.py
@@ -4,12 +4,15 @@ Parsing games from the ESPN API
 
 import json
 from csv import DictWriter
+from logging import getLogger
 from typing import Callable, Dict, List, NamedTuple, Optional
 
 from dateutil import parser
 
 from .types import Game, Season
 from .web import RequestParameters, get
+
+logger = getLogger(__name__)
 
 # Whether one of ESPN's events is a game the caller wants at all.
 #
@@ -119,11 +122,31 @@ def parse_game(event: Dict) -> Optional[Game]:
         else:
             home_index, away_index = 1, 0
 
+    home_score = competitiors[home_index].score
+    away_score = competitiors[away_index].score
+    if home_score is None or away_score is None:
+        # ESPN lists the occasional fixture it never fills in -- a scheduled
+        # game that got superseded, left on "TBD" with no score on either
+        # side. The 2002 WNBA has a couple in its postseason, and used to
+        # take the whole season's fetch down on the int() below.
+        #
+        # A game with no score hasn't been played, whatever `completed` says,
+        # so it's recorded as unfinished with a nil score rather than
+        # dropped. Both matter: `get_games` discards unfinished games from
+        # what it returns, *and* refuses to cache a response containing one,
+        # which is what keeps a week whose games haven't happened yet out of
+        # the cache. Returning None here would lose the second one.
+        logger.info(
+            "No score for %s, treating it as unplayed",
+            event.get("name", event["id"]),
+        )
+        home_score, away_score, completed = 0, 0, False
+
     return Game(
         home=competitiors[home_index].name,
-        home_score=competitiors[home_index].score,
+        home_score=home_score,
         away=competitiors[away_index].name,
-        away_score=competitiors[away_index].score,
+        away_score=away_score,
         neutral_site=neutral_site,
         completed=completed,
         date=parser.parse(event["date"]),
@@ -133,13 +156,16 @@ def parse_game(event: Dict) -> Optional[Game]:
 
 class _Competitior(NamedTuple):
     name: str
-    score: int
+    # None when ESPN listed the fixture but never filled in a result. Not the
+    # same as 0, which the NHL's pre-2005 ties really did finish on.
+    score: Optional[int]
     is_home: bool
 
 
 def _parse_competitor(competitor: Dict) -> _Competitior:
+    score = competitor.get("score")
     return _Competitior(
         name=competitor["team"]["displayName"],
-        score=int(competitor["score"]),
+        score=None if score is None else int(score),
         is_home=competitor["homeAway"] == "home",
     )

--- a/py-endgame/endgame/espn_games_test.py
+++ b/py-endgame/endgame/espn_games_test.py
@@ -73,3 +73,77 @@ async def test_filter_can_drop_everything() -> None:
 def test_keep_every_event_is_the_default() -> None:
     assert keep_every_event(_event("a"))
     assert keep_every_event({})
+
+
+def _unscored_event(event_id: str, completed: bool = False) -> Dict:
+    """
+    A fixture ESPN listed and never filled in: no `score` on either side.
+
+    Modelled on the two in the 2002 WNBA postseason (ids 220820009 and
+    220820004), which are "STATUS_TBD" with no score anywhere.
+    """
+    event = _event(event_id)
+    event["status"] = {"type": {"completed": completed}}
+    for competitor in event["competitions"][0]["competitors"]:
+        del competitor["score"]
+    return event
+
+
+async def test_unscored_event_does_not_raise() -> None:
+    """
+    A missing score used to take a whole season's fetch down on int(None).
+    """
+    with _patch_get([_unscored_event("tbd")]):
+        games = await get_games("http://espn", {})
+    assert games == []
+
+
+async def test_unscored_event_is_unfinished_even_if_espn_says_otherwise() -> None:
+    """
+    No score means it hasn't been played, whatever `completed` claims.
+    """
+    with _patch_get([_unscored_event("tbd", completed=True)]):
+        games = await get_games("http://espn", {})
+    # get_games only returns completed games, so an unscored one never
+    # reaches a caller either way.
+    assert games == []
+
+
+async def test_unscored_event_keeps_the_day_out_of_the_cache() -> None:
+    """
+    The reason an unscored game is kept as unfinished rather than dropped:
+    a response holding one mustn't be cached, or a week gets frozen before
+    its games have been played.
+    """
+    content = AsyncMock()
+    content.data = json.dumps({"events": [_event("played"), _unscored_event("tbd")]})
+    with patch.object(espn_games_module, "get", AsyncMock(return_value=content)):
+        games = await get_games("http://espn", {})
+
+    assert [g.game_id for g in games] == ["played"]
+    content.save_if_necessary.assert_not_awaited()
+
+
+async def test_a_fully_played_day_is_cached() -> None:
+    content = AsyncMock()
+    content.data = json.dumps({"events": [_event("played")]})
+    with patch.object(espn_games_module, "get", AsyncMock(return_value=content)):
+        await get_games("http://espn", {})
+
+    content.save_if_necessary.assert_awaited()
+
+
+async def test_a_zero_zero_game_is_still_a_result() -> None:
+    """
+    Missing isn't zero: the NHL played to ties until 2005-06, so a real 0-0
+    has to survive.
+    """
+    event = _event("tie")
+    for competitor in event["competitions"][0]["competitors"]:
+        competitor["score"] = "0"
+    with _patch_get([event]):
+        games = await get_games("http://espn", {})
+
+    assert [(g.game_id, g.home_score, g.away_score, g.completed) for g in games] == [
+        ("tie", 0, 0, True)
+    ]

--- a/py-endgame/endgame/wnba.py
+++ b/py-endgame/endgame/wnba.py
@@ -58,6 +58,12 @@ WNBA = DailyLeague(
     # sits outside the standings. The All-Star game, which shares its
     # week, does not -- that one is "ALLSTAR" and gets dropped.
     regular_season_competitions=frozenset({"STD", "CC"}),
+    # The 2002 All-Star game, EAST v WEST on July 15th. ESPN tagged every
+    # All-Star game from 2003 on, and both leagues', but filed this one as
+    # an ordinary regular-season game -- so it's the single game in either
+    # league's history that no rule can tell from league play, and without
+    # it "EAST" and "WEST" end up rated off one game apiece.
+    untagged_exhibitions=frozenset({"220715098"}),
 )
 
 


### PR DESCRIPTION
The 2002 WNBA season couldn't be fetched at all: int(competitor["score"]) raised KeyError on two postseason events ESPN lists as "STATUS_TBD" with no score on either side -- fixtures that got superseded (the games those placeholders stood for were played on the 22nd and are recorded there) and never filled in. One of them took the whole season down.

A game with no score hasn't been played, whatever the status says, so it's recorded as unfinished with a nil score rather than skipped. Both halves matter: get_games drops unfinished games from what it returns *and* refuses to cache a response holding one, which is what keeps a week whose games haven't happened yet from being frozen. Returning None would have kept the first and quietly lost the second.

Missing is not zero, so the score parses as Optional and only the missing case is special -- the NHL's pre-2005 ties really did finish 0-0.

That gets 2002 fetching, which turns up the one exhibition no rule can catch: the 2002 All-Star game is filed as an ordinary regular-season game. ESPN tagged every other one in both leagues from 2003 on, so rather than weaken the rule for a single event, DailyLeague takes a set of ids and wnba names it. Without it "EAST" and "WEST" get rated off one game each.

  2002 before: fetch fails
  2002 after:  271 games, 16 teams, 32-39 games each, no phantoms