### PR TITLE
take the NHL back to 1993-94

### DIFF
--- a/py-endgame/endgame/daily.py
+++ b/py-endgame/endgame/daily.py
@@ -39,7 +39,7 @@ from .web import RequestParameters
 logger = getLogger(__name__)
 
 
-def _keep_name(name: str) -> str:
+def _keep_name(name: str, day: date) -> str:
     return name
 
 
@@ -70,8 +70,12 @@ class DailyLeague:
     # there is a real result.
     drop_scoreless: bool
     # Franchises that ESPN lists under more than one name over the years,
-    # collapsed onto the current one so a team is one team across seasons
-    rename_team: Callable[[str], str] = field(default=_keep_name)
+    # collapsed onto the current one so a team is one team across seasons.
+    #
+    # Takes the day the game was played as well as the name, because a name
+    # on its own isn't always enough to say which franchise it is: "Winnipeg
+    # Jets" is one franchise before 1996 and a different one after 2011.
+    rename_team: Callable[[str, date], str] = field(default=_keep_name)
     # Seasons that didn't run when they normally do, as season year ->
     # (first day, the day it's over by). The shared window is deliberately
     # loose, but a season that moves by months rather than days can't be
@@ -356,6 +360,7 @@ async def get_daily_odds(league: DailyLeague, day: date) -> AsyncIterator[Odds]:
 
 def _rename_teams(league: DailyLeague, game: Game) -> Game:
     game_dict = game.to_dict()
-    game_dict["away"] = league.rename_team(game_dict["away"])
-    game_dict["home"] = league.rename_team(game_dict["home"])
+    day = game.date.date()
+    game_dict["away"] = league.rename_team(game_dict["away"], day)
+    game_dict["home"] = league.rename_team(game_dict["home"], day)
     return Game(**game_dict)

--- a/py-endgame/endgame/daily_test.py
+++ b/py-endgame/endgame/daily_test.py
@@ -380,7 +380,10 @@ async def test_wnba_drops_scoreless_games() -> None:
 @pytest.mark.parametrize(
     "league, old_name, current_name",
     [
-        pytest.param(NHL, "Mighty Ducks of Anaheim", "Anaheim Ducks", id="nhl-rename"),
+        # ESPN's own spelling. The name this used to carry, "Mighty Ducks
+        # of Anaheim", is the one nothing ever sends -- so this passed while
+        # the rename it was checking never fired on a real game.
+        pytest.param(NHL, "Anaheim Mighty Ducks", "Anaheim Ducks", id="nhl-rename"),
         pytest.param(NHL, "Atlanta Thrashers", "Winnipeg Jets", id="nhl-move"),
         pytest.param(NHL, "Arizona Coyotes", "Utah Mammoth", id="nhl-move-again"),
         pytest.param(WNBA, "Tulsa Shock", "Dallas Wings", id="wnba-move"),
@@ -565,3 +568,45 @@ def test_an_ordinary_game_keeps_its_id() -> None:
     ordinary = _espn_event(2, "STD", "Chicago Sky at Connecticut Sun")
     ordinary["id"] = "401244567"
     assert league_play_filter(WNBA)(ordinary)
+
+
+@pytest.mark.parametrize(
+    "name,day,expected",
+    [
+        # The first Winnipeg franchise: Jets until 1996, then Phoenix, and
+        # Utah now.
+        ("Winnipeg Jets", date(1994, 11, 20), "Utah Mammoth"),
+        ("Winnipeg Jets", date(1996, 3, 1), "Utah Mammoth"),
+        ("Phoenix Coyotes", date(1997, 11, 20), "Utah Mammoth"),
+        ("Arizona Coyotes", date(2015, 11, 20), "Utah Mammoth"),
+        # The second one, which is the old Atlanta Thrashers and stays put.
+        ("Winnipeg Jets", date(2013, 11, 20), "Winnipeg Jets"),
+        ("Atlanta Thrashers", date(2005, 11, 20), "Winnipeg Jets"),
+        # Franchises that moved inside the range now reachable.
+        ("Quebec Nordiques", date(1994, 11, 20), "Colorado Avalanche"),
+        ("Hartford Whalers", date(1995, 11, 20), "Carolina Hurricanes"),
+        # ESPN's spelling of the Ducks before they dropped the "Mighty".
+        ("Anaheim Mighty Ducks", date(2003, 11, 20), "Anaheim Ducks"),
+        ("Anaheim Ducks", date(2011, 11, 20), "Anaheim Ducks"),
+        # Something that never moved.
+        ("Boston Bruins", date(1994, 11, 20), "Boston Bruins"),
+    ],
+)
+def test_nhl_renames(name: str, day: date, expected: str) -> None:
+    assert NHL.rename_team(name, day) == expected
+
+
+def test_the_two_winnipeg_franchises_stay_apart() -> None:
+    """
+    The reason renaming takes a date: one name, two franchises that never
+    overlapped, and merging them hands one's history to the other.
+    """
+    old = NHL.rename_team("Winnipeg Jets", date(1994, 11, 20))
+    new = NHL.rename_team("Winnipeg Jets", date(2013, 11, 20))
+    assert old != new
+
+
+def test_wnba_renames_ignore_the_day() -> None:
+    for day in (date(2003, 6, 1), date(2025, 6, 1)):
+        assert WNBA.rename_team("Detroit Shock", day) == "Dallas Wings"
+        assert WNBA.rename_team("Minnesota Lynx", day) == "Minnesota Lynx"

--- a/py-endgame/endgame/espn_games.py
+++ b/py-endgame/endgame/espn_games.py
@@ -165,7 +165,20 @@ class _Competitior(NamedTuple):
 def _parse_competitor(competitor: Dict) -> _Competitior:
     score = competitor.get("score")
     return _Competitior(
-        name=competitor["team"]["displayName"],
+        name=_clean_name(competitor["team"]["displayName"]),
         score=None if score is None else int(score),
         is_home=competitor["homeAway"] == "home",
     )
+
+
+def _clean_name(name: str) -> str:
+    """
+    One space between words.
+
+    ESPN's older hockey rows are column-padded -- "Boston          Bruins"
+    through the 1998-99 season, "Boston Bruins" from 1999-2000 on. Left
+    alone, that's the same team under two names either side of a season
+    nothing happened in. Nothing else this fetches is padded, so on
+    everything else this is a no-op.
+    """
+    return " ".join(name.split())

--- a/py-endgame/endgame/espn_games_test.py
+++ b/py-endgame/endgame/espn_games_test.py
@@ -147,3 +147,27 @@ async def test_a_zero_zero_game_is_still_a_result() -> None:
     assert [(g.game_id, g.home_score, g.away_score, g.completed) for g in games] == [
         ("tie", 0, 0, True)
     ]
+
+
+async def test_padded_names_are_collapsed() -> None:
+    """
+    ESPN's pre-1999 hockey rows are column-padded.
+    """
+    event = _event(
+        "padded", home="Boston          Bruins", away="Quebec        Nordiques"
+    )
+    with _patch_get([event]):
+        games = await get_games("http://espn", {})
+
+    assert [(g.home, g.away) for g in games] == [("Boston Bruins", "Quebec Nordiques")]
+
+
+async def test_unpadded_names_are_untouched() -> None:
+    with _patch_get(
+        [_event("plain", home="Boston Bruins", away="Toronto Maple Leafs")]
+    ):
+        games = await get_games("http://espn", {})
+
+    assert [(g.home, g.away) for g in games] == [
+        ("Boston Bruins", "Toronto Maple Leafs")
+    ]

--- a/py-endgame/endgame/nhl.py
+++ b/py-endgame/endgame/nhl.py
@@ -39,20 +39,42 @@ ODD_SEASONS = {
 }
 
 
-def _rename_team(name: str) -> str:
+# The day the original Winnipeg franchise stopped being Winnipeg's: it
+# played its last season as the Jets in 1995-96 and opened 1996-97 in
+# Phoenix. See `_rename_team` for why this needs a date at all.
+_JETS_LEFT_WINNIPEG = date(1996, 7, 1)
+
+
+def _rename_team(name: str, day: date) -> str:
     """
     Collapse a franchise's old names onto its current one, so a team is one
     team across seasons.
+
+    "Winnipeg Jets" is two different franchises and can't go in the table
+    below, because the table is keyed on the name alone. The first Jets
+    moved to Phoenix in 1996 and are now Utah; the team playing as the Jets
+    since 2011 is the old Atlanta Thrashers, which never went near Phoenix.
+    Mapping the name without asking when would hand one franchise's whole
+    history to the other.
     """
+    if name == "Winnipeg Jets" and day < _JETS_LEFT_WINNIPEG:
+        return "Utah Mammoth"
     return _RENAMES.get(name, name)
 
 
 _RENAMES = {
-    # Dropped the "Mighty" in 2006
-    "Mighty Ducks of Anaheim": "Anaheim Ducks",
+    # Dropped the "Mighty" in 2006. ESPN writes this "Anaheim Mighty Ducks",
+    # not "Mighty Ducks of Anaheim" -- the old key here never matched a
+    # single game, so 2002-2005 has been rating them as a separate team.
+    "Anaheim Mighty Ducks": "Anaheim Ducks",
     # Atlanta's franchise moved to Winnipeg in 2011
     "Atlanta Thrashers": "Winnipeg Jets",
-    # Phoenix -> Arizona in 2014, then Utah in 2024, renamed again in 2025
+    # Quebec's moved to Denver in 1995
+    "Quebec Nordiques": "Colorado Avalanche",
+    # Hartford's moved to Carolina in 1997
+    "Hartford Whalers": "Carolina Hurricanes",
+    # Winnipeg -> Phoenix in 1996 (see `_rename_team`), Phoenix -> Arizona
+    # in 2014, then Utah in 2024, renamed again in 2025
     "Phoenix Coyotes": "Utah Mammoth",
     "Arizona Coyotes": "Utah Mammoth",
     "Utah Hockey Club": "Utah Mammoth",
@@ -66,7 +88,9 @@ NHL = DailyLeague(
     season_end=SEASON_END,
     # October to June, so a season runs into the next calendar year
     end_year_offset=1,
-    first_year=2002,
+    # ESPN's hockey coverage starts here: 1993-94 comes back complete and
+    # scored, 1992-93 comes back empty.
+    first_year=1993,
     # The NHL played to ties until 2005-06, so a 0-0 final is a real result
     # and scoreless games can't be thrown away as bad data.
     drop_scoreless=False,

--- a/py-endgame/endgame/wnba.py
+++ b/py-endgame/endgame/wnba.py
@@ -20,10 +20,13 @@ SEASON_START = (5, 1)
 SEASON_END = (10, 31)
 
 
-def _rename_team(name: str) -> str:
+def _rename_team(name: str, day: date) -> str:
     """
     Collapse a franchise's old names onto its current one, so a team is one
     team across seasons.
+
+    `day` goes unused here -- no WNBA name has ever meant two franchises --
+    but the signature is shared, and the NHL's Jets need it.
     """
     return _RENAMES.get(name, name)
 


### PR DESCRIPTION
first_year was 2002, which wasn't where ESPN's coverage starts: 1993-94 comes back complete and scored, and 1992-93 comes back empty. That's nine seasons the models never saw.

Three things had to be right first, because each one silently splits or merges a franchise rather than failing:

Names are column-padded through 1998-99 -- "Boston          Bruins" --
and clean from 1999-2000. Collapsed at the parse layer, where it's a
no-op for everything else: no other league is padded in any era.

"Winnipeg Jets" is two franchises. The first moved to Phoenix in 1996 and is Utah now; the one playing since 2011 is the old Atlanta Thrashers, which the rename table already maps onto the name. Keying "Winnipeg Jets" by name alone would have given today's team Utah's history, so renaming takes the game's date and the pre-1996 Jets resolve to Utah.

And the Ducks rename has never once fired: the table keys them as "Mighty Ducks of Anaheim", but ESPN says "Anaheim Mighty Ducks". That's not new with this change -- 2002-2005 has been rating them as a team of their own all along. The test covering it asserted the table's own key rather than ESPN's, which is how it stayed green.

Quebec and Hartford both move inside the newly reachable range, so they join the table too.

Fetched, with the renames resolving to one continuous franchise each:

  1993: 1182 games, 26 teams, 84-108 each   (84-game season)
  1994:  705 games, 26 teams, 48-68 each    (lockout, opens Jan 20th)
  1995: 1152 games, 26 teams, 82-104 each
  1996: 1148 games, 26 teams, 82-102 each

No phantom teams in any of them, so the exhibition filter holds up on the old data too.