### PR TITLE
bump py-endgame for the 1993 NHL seasons

### DIFF
--- a/py-endgame-aws/poetry.lock
+++ b/py-endgame-aws/poetry.lock
@@ -540,8 +540,8 @@ python-dateutil = "^2.8.2"
 [package.source]
 type = "git"
 url = "https://github.com/NathanDeMaria/EndGame.git"
-reference = "f67b098da0b3cd134a0635bac183df382be15c7d"
-resolved_reference = "f67b098da0b3cd134a0635bac183df382be15c7d"
+reference = "7879d5283fcc14a38f37835ad7e2501b79560ad3"
+resolved_reference = "7879d5283fcc14a38f37835ad7e2501b79560ad3"
 subdirectory = "py-endgame"
 
 [[package]]
@@ -2591,4 +2591,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "1e31292ead56eb72ecb962d77e851bbc3fdc30b375da2c44f474d95cf97ad602"
+content-hash = "81946eb4e6834410aea2e0895894a4f820696586328ae06a60d930cb906f1658"

--- a/py-endgame-aws/pyproject.toml
+++ b/py-endgame-aws/pyproject.toml
@@ -11,7 +11,7 @@ authors = []
 python = "^3.12"
 fire = ">=0.4.0,<1.0"
 aiobotocore = "^3.9.0"
-endgame = {git = "https://github.com/NathanDeMaria/EndGame.git", rev = "f67b098da0b3cd134a0635bac183df382be15c7d", subdirectory = "py-endgame"}
+endgame = {git = "https://github.com/NathanDeMaria/EndGame.git", rev = "7879d5283fcc14a38f37835ad7e2501b79560ad3", subdirectory = "py-endgame"}
 dataclasses-json = ">=0.5.7,<1.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The pin moves once per py-endgame change that the image needs, and the last one landed before the NHL work. This picks up:

  - the NHL back to 1993-94, nine seasons earlier than before
  - names unpadded, so a franchise is one team either side of 1999
  - renaming by date, so the two Winnipeg franchises stay apart
  - Quebec, Hartford, and the Ducks rename that never fired

That last one changes seasons that already exist: "Anaheim Mighty Ducks" folds into "Anaheim Ducks", so 2002-2005 stops carrying them as a team of their own. Worth landing before the pickles are rebuilt rather than after.

Lock touched only for that dependency.