### PR TITLE
Fetch NCAAFB week 0, and make a season merge non-destructive

### DIFF
--- a/py-endgame/endgame/ncaafb.py
+++ b/py-endgame/endgame/ncaafb.py
@@ -33,6 +33,21 @@ SEASON_END = (2, 1)
 # playoffs sitting in regular season weeks 14-16. So the season is tagged
 # with a start and walked as calendar weeks instead.
 SEASON_START = (8, 20)
+# ESPN files the handful of games that open the season -- the Saturday
+# before Labour Day weekend -- under week 0, and only from this season on.
+# Before it the regular season starts at week 1, and asking for 0 comes back
+# empty or 404s for every division: three trouble weeks added to every
+# historical season, which would blunt the signal `trouble_params` is there
+# to carry.
+#
+# Gated by year rather than by "an empty week 0 is fine" so that a week 0
+# that *should* have games and doesn't still shows up as trouble.
+#
+# This year is a starting point, not a fact to trust: `backfill_week_zero
+# --dry_run` reports what week 0 adds per season, so lower it and re-run the
+# dry run if an earlier year turns out to have any. A dry run costs a
+# re-fetch and writes nothing.
+FIRST_WEEK_ZERO_SEASON = 2016
 
 
 async def update(location="ncaaf.csv"):
@@ -43,6 +58,22 @@ async def update(location="ncaaf.csv"):
     args = [(y,) for y in range(1999, end_year + 1)]
     seasons = [s async for s in apply_in_parallel(get_season, args)]
     save_seasons(seasons, location)
+
+
+def _week_params(year: int) -> List[WeekParams]:
+    """
+    Every request a season is made of: each division, each week, plus the
+    postseason.
+
+    Week 0 only from `FIRST_WEEK_ZERO_SEASON` on -- see the constant.
+    """
+    first_week = 0 if year >= FIRST_WEEK_ZERO_SEASON else 1
+    week_params: List[WeekParams] = []
+    for group in NcaaFbGroup:
+        for week_num in range(first_week, N_REGULAR_WEEKS + 1):
+            week_params.append(WeekParams(year, week_num, SeasonType.regular, group))
+        week_params.append(WeekParams(year, 1, SeasonType.post, group))
+    return week_params
 
 
 async def get_season(year: int) -> Season:
@@ -56,11 +87,7 @@ async def get_season(year: int) -> Season:
     if season:
         return season.with_season_start(SEASON_START)
 
-    week_params: List[WeekParams] = []
-    for group in NcaaFbGroup:
-        for week_num in range(1, N_REGULAR_WEEKS + 1):
-            week_params.append(WeekParams(year, week_num, SeasonType.regular, group))
-        week_params.append(WeekParams(year, 1, SeasonType.post, group))
+    week_params = _week_params(year)
 
     weeks = []
     trouble_weeks: List[WeekParams] = []

--- a/py-endgame/endgame/ncaafb_test.py
+++ b/py-endgame/endgame/ncaafb_test.py
@@ -1,7 +1,15 @@
 from datetime import datetime, timezone
 
-from .ncaafb import SEASON_START
-from .types import Game, Season, Week, group_games_into_weeks, iter_weeks
+from .ncaafb import FIRST_WEEK_ZERO_SEASON, SEASON_START, _week_params
+from .types import (
+    Game,
+    NcaaFbGroup,
+    Season,
+    SeasonType,
+    Week,
+    group_games_into_weeks,
+    iter_weeks,
+)
 
 
 def _game(month: int, day: int, game_id: str, year: int = 2021) -> Game:
@@ -48,3 +56,45 @@ def test_season_walks_chronologically() -> None:
         ["fcs_semifinal"],
         ["title"],
     ]
+
+
+def test_week_zero_is_asked_for_from_the_season_espn_has_one() -> None:
+    """The games that open the season sit in week 0, and were never fetched.
+
+    UNC and TCU kicking off on the Saturday before Labour Day weekend is
+    the case: the season file had weeks 1-16 and none of the games anyone
+    actually wanted to look at that day.
+    """
+    params = _week_params(FIRST_WEEK_ZERO_SEASON)
+
+    regular = [p for p in params if p.season_type is SeasonType.regular]
+    assert min(p.week for p in regular) == 0
+    # Every division, not just FBS -- week 0 has FCS games in it too.
+    assert {p.group for p in regular if p.week == 0} == set(NcaaFbGroup)
+
+
+def test_week_zero_is_not_asked_for_before_that() -> None:
+    """A year with no week 0 must not spend three requests finding that out.
+
+    They'd come back empty or 404, and a 404 lands in `trouble_params` --
+    which is the signal for "this season is missing something", so filling
+    it with a permanent, expected absence is how that signal stops meaning
+    anything.
+    """
+    params = _week_params(FIRST_WEEK_ZERO_SEASON - 1)
+
+    assert min(p.week for p in params if p.season_type is SeasonType.regular) == 1
+
+
+def test_the_rest_of_the_season_is_unchanged_either_side_of_the_gate() -> None:
+    with_zero = _week_params(FIRST_WEEK_ZERO_SEASON)
+    without = _week_params(FIRST_WEEK_ZERO_SEASON - 1)
+
+    def without_year(params):
+        return {(p.week, p.season_type, p.group) for p in params}
+
+    # The gate adds week 0 and touches nothing else.
+    assert without_year(with_zero) - without_year(without) == {
+        (0, SeasonType.regular, group) for group in NcaaFbGroup
+    }
+    assert without_year(without) - without_year(with_zero) == set()

--- a/py-endgame/endgame/types.py
+++ b/py-endgame/endgame/types.py
@@ -235,6 +235,63 @@ def group_games_into_weeks(
     ]
 
 
+def merge_weekly_seasons(seasons: List[Season]) -> Season:
+    """
+    Fold seasons of the same year together, keeping the latest copy of a
+    game that shows up in more than one of them.
+
+    The later season wins per game, so a re-pull corrects a score. What it
+    cannot do is *drop* a game: anything only an earlier season knows about
+    survives. That is the property that makes a partial fetch safe to write
+    over a complete one -- before this, a pull that lost a week to an ESPN
+    5xx replaced the season with a smaller one and said nothing.
+
+    Unlike the merge in `daily.py`, this keeps the week each game was
+    fetched under. Leagues pulled a week at a time carry the source's week
+    numbers on their Week objects -- they're how you trace a game back to
+    the request that brought it -- and rebuilding the weeks from game dates
+    would quietly throw that away. Leagues pulled a day at a time put
+    everything in one week, so folding them through here is a no-op on
+    their grouping and works the same.
+    """
+    assert all(s.year == seasons[0].year for s in seasons)
+
+    latest: Dict[str, Tuple[int, Game]] = {}
+    for season in seasons:
+        for week in season.weeks:
+            for game in week.games:
+                latest[game.game_id] = (week.number, game)
+
+    by_number: Dict[int, List[Game]] = {}
+    for number, game in latest.values():
+        by_number.setdefault(number, []).append(game)
+
+    # dict.fromkeys rather than a sorted set: trouble params hold enums
+    # (SeasonType, NcaaFbGroup), and enums don't order, so sorting them
+    # raises. This dedupes and keeps a stable order without asking them to
+    # compare.
+    trouble: Dict[Any, None] = {}
+    for season in seasons:
+        for param in season.trouble_params or []:
+            trouble[param] = None
+
+    return Season(
+        [
+            Week(sorted(games, key=lambda g: g.date), number)
+            for number, games in sorted(by_number.items())
+        ],
+        seasons[0].year,
+        list(trouble),
+        # The freshest tag wins. A season pickled before `season_start`
+        # existed comes back untagged, and merging one of those in must not
+        # untag the season it's being folded into.
+        next(
+            (s.season_start for s in reversed(seasons) if s.season_start is not None),
+            None,
+        ),
+    )
+
+
 class OverlappingWeeksError(ValueError):
     """
     Raised when a season's weeks cover overlapping stretches of time.

--- a/py-endgame/endgame/types_test.py
+++ b/py-endgame/endgame/types_test.py
@@ -4,11 +4,15 @@ import pytest
 
 from .types import (
     Game,
+    NcaaFbGroup,
     OverlappingWeeksError,
     Season,
+    SeasonType,
     Week,
+    WeekParams,
     check_weeks_dont_overlap,
     iter_weeks,
+    merge_weekly_seasons,
 )
 
 
@@ -230,3 +234,97 @@ def test_iter_weeks_walks_source_weeks_without_a_season_start() -> None:
     season = Season([Week([_game(13)], 2), Week([_game(6)], 1)], 2023)
 
     assert [w.number for w in iter_weeks(season)] == [1, 2]
+
+
+def _scored(game: Game, home_score: int, away_score: int) -> Game:
+    return game._replace(home_score=home_score, away_score=away_score)
+
+
+class TestMergeWeeklySeasons:
+    """Folding a fresh pull over what's already saved.
+
+    The property that matters is that a merge can only add and correct.
+    Before it, `games` wrote whatever the fetch returned straight over the
+    season in the bucket -- so a pull that lost a week to an ESPN 5xx
+    replaced a complete season with a smaller one, silently.
+    """
+
+    def test_a_game_only_the_old_season_has_survives(self) -> None:
+        old = Season([Week([_game(4, "kept")], 1)], 2023)
+        # What a pull that dropped a week looks like: fewer games, no error.
+        partial = Season([Week([_game(11, "fresh")], 2)], 2023)
+
+        merged = merge_weekly_seasons([old, partial])
+
+        assert {g.game_id for w in merged.weeks for g in w.games} == {
+            "kept",
+            "fresh",
+        }
+
+    def test_an_empty_pull_cannot_empty_the_season(self) -> None:
+        old = Season([Week([_game(4, "kept")], 1)], 2023)
+
+        merged = merge_weekly_seasons([old, Season([], 2023)])
+
+        assert [g.game_id for w in merged.weeks for g in w.games] == ["kept"]
+
+    def test_the_later_copy_wins(self) -> None:
+        """A score gets corrected upstream, so the fresh copy has to win."""
+        stale = _game(4, "game")
+        old = Season([Week([stale], 1)], 2023)
+        fresh = Season([Week([_scored(stale, 42, 17)], 1)], 2023)
+
+        merged = merge_weekly_seasons([old, fresh])
+
+        [game] = [g for w in merged.weeks for g in w.games]
+        assert (game.home_score, game.away_score) == (42, 17)
+
+    def test_each_game_keeps_the_week_it_was_fetched_under(self) -> None:
+        """ESPN's week numbers are how a game is traced back to its request.
+
+        Merging through a date-based regroup -- which is what the daily
+        leagues' merge does -- would replace them with calendar weeks and
+        lose that.
+        """
+        old = Season([Week([_game(4, "early")], 3)], 2023)
+        fresh = Season([Week([_game(11, "late")], 9)], 2023)
+
+        merged = merge_weekly_seasons([old, fresh])
+
+        assert {w.number: [g.game_id for g in w.games] for w in merged.weeks} == {
+            3: ["early"],
+            9: ["late"],
+        }
+
+    def test_trouble_params_are_unioned_without_being_sorted(self) -> None:
+        """They hold enums, and enums don't order.
+
+        Deduping through a sorted set raises TypeError here, which is the
+        kind of thing that only shows up on the one season that had a bad
+        week.
+        """
+        first = WeekParams(2023, 3, SeasonType.regular, NcaaFbGroup.fbs)
+        second = WeekParams(2023, 9, SeasonType.post, NcaaFbGroup.fcs)
+        old = Season([], 2023, [first, second])
+        fresh = Season([], 2023, [second])
+
+        merged = merge_weekly_seasons([old, fresh])
+
+        assert merged.trouble_params is not None
+        assert set(merged.trouble_params) == {first, second}
+        assert len(merged.trouble_params) == 2
+
+    def test_an_untagged_old_season_does_not_untag_the_new_one(self) -> None:
+        """Seasons pickled before `season_start` existed come back untagged.
+
+        Taking the first one's tag would drop the new season's, and the
+        chronological walk silently goes back to the source's week order.
+        """
+        untagged = Season([Week([_game(4, "old")], 1)], 2023)
+        tagged = Season([Week([_game(11, "new")], 2)], 2023, [], (8, 20))
+
+        assert merge_weekly_seasons([untagged, tagged]).season_start == (8, 20)
+
+    def test_it_refuses_seasons_from_different_years(self) -> None:
+        with pytest.raises(AssertionError):
+            merge_weekly_seasons([Season([], 2023), Season([], 2024)])


### PR DESCRIPTION
The games that open the college football season — the Saturday before Labour Day weekend — come back from ESPN under **week 0**, and `get_season` has always asked for weeks 1..16. So the opening weekend has never been in a season file.

It surfaced through the webapp: on the day itself the site showed no D1 football at all, while weeks 1–16 sat in the pickle looking perfectly complete.

This is the `py-endgame` half. The `endgame_aws` half is [claude/ncaafb-week-zero-aws](https://github.com/NathanDeMaria/endgame/compare/claude/ncaafb-week-zero-aws) and is **blocked on this merging**, because `py-endgame-aws` pins `endgame` by git rev and needs a bump to reach `merge_weekly_seasons`. Details at the bottom.

## Week 0, gated by year

```python
first_week = 0 if year >= FIRST_WEEK_ZERO_SEASON else 1
```

Gated by **year** rather than by "an empty week 0 is fine", so that a week 0 which *should* have games and doesn't still lands in `trouble_params`. The alternative would have made every pre-2016 season carry three permanent, expected trouble entries and blunted the one signal that says a season is missing something.

`FIRST_WEEK_ZERO_SEASON = 2016` is a starting point rather than a fact to trust. The backfill's dry run reports what week 0 adds per season, so an earlier year showing games is the cue to lower it — and a dry run costs a re-fetch and writes nothing.

`_week_params` comes out of `get_season` so the gate is testable without standing up a fetch and a cache.

## `merge_weekly_seasons`

Folds seasons of a year together, later copy winning per game id, keeping the week each game was fetched under. The point is what it **can't** do: drop a game. Anything only the older season knows about survives — which is what makes a partial fetch safe to write over a complete one, and is the precondition for backfilling every year.

Deliberately **not** the merge in `daily.py`, which rebuilds weeks from game dates. That's right for leagues pulled a day at a time — they have no source grouping to keep — and wrong here, where ESPN's week numbers are how a game is traced back to the request that brought it. Leagues pulled by day put everything in one week, so folding them through this instead is a no-op on their grouping and lets both sides share one write path later.

Two details that each only bite once, and both have a test:

- **Trouble params hold enums**, so deduping them through a sorted set raises `TypeError` — `daily.py`'s `sorted(trouble_params)` works only because `DayParams` is dates. This uses `dict.fromkeys` ordering instead.
- **A season pickled before `season_start` existed comes back untagged.** Taking the first season's tag would drop the fresh one's, and the chronological walk would silently revert to the source's week order. The freshest non-`None` tag wins.

## Tests

10 new, all in the existing colocated style:

| | |
|---|---|
| `test_a_game_only_the_old_season_has_survives` | the anti-data-loss property |
| `test_an_empty_pull_cannot_empty_the_season` | the ESPN-5xx case |
| `test_the_later_copy_wins` | a corrected score has to land |
| `test_each_game_keeps_the_week_it_was_fetched_under` | why not `daily.py`'s merge |
| `test_trouble_params_are_unioned_without_being_sorted` | the enum trap |
| `test_an_untagged_old_season_does_not_untag_the_new_one` | the `season_start` trap |
| `test_week_zero_is_asked_for_from_the_season_espn_has_one` | all divisions, not just FBS |
| `test_week_zero_is_not_asked_for_before_that` | the gate |
| `test_the_rest_of_the_season_is_unchanged_either_side_of_the_gate` | the gate adds week 0 and nothing else |

`184 passed` (was 174), `ruff format --check`, `ruff check` and `ty check` clean.

Two failures in `ncaabb/plays_test.py` are pre-existing and unrelated — they call the live ESPN API, which my sandbox blocks.

## Follow-up, in order

1. **Merge this.**
2. Bump the `endgame` pin in `py-endgame-aws/pyproject.toml` to this merge's SHA, then merge the aws branch — it adds merge-on-write, a shrink guard, and `backfill_week_zero`. Its lint can't pass before the bump, since it imports `merge_weekly_seasons`.
3. Run `backfill_week_zero` — dry run, one year, read the numbers, then the range.

Worth knowing separately: **CI lints but never runs `pytest`.** These tests are the reason I noticed. Happy to add the step if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pcitn8aph8CNZ521f7AY9e)_