### PR TITLE
Run the tests in CI

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -34,8 +34,37 @@ jobs:
       working-directory: ${{ matrix.package }}
       run: poetry run ty check .
 
+  # Not matrixed over both packages the way `lint` is, because only one of
+  # them has tests a merge gate can run. py-endgame-aws's `stores_test.py`
+  # lists a real S3 bucket and `main_test.py` is a hand-run script rather
+  # than a test at all -- so there is nothing there to gate on yet, and
+  # pretending otherwise would mean wiring AWS credentials into a job that
+  # currently needs none.
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install poetry
+      run: pip install poetry
+    - name: Install dependencies
+      working-directory: py-endgame
+      run: poetry install
+    # `not network` drops the two play-by-play tests, which call ESPN for
+    # real and assert exact counts against what it serves back. They are
+    # worth having and a local `pytest` still runs them; they are not worth
+    # gating a merge on, because then an ESPN outage, a rate limit, or a
+    # play-by-play revised upstream fails the build for reasons that have
+    # nothing to do with the commit.
+    - name: pytest
+      working-directory: py-endgame
+      run: poetry run pytest -m "not network"
+
   make-push:
-    needs: lint
+    needs: [lint, test]
     runs-on: ubuntu-latest
 
     env:

--- a/py-endgame/endgame/ncaabb/plays_test.py
+++ b/py-endgame/endgame/ncaabb/plays_test.py
@@ -1,7 +1,17 @@
 from datetime import date
 
+import pytest
+
 from .ncaabb import NcaabbGender
 from .plays import get_plays, get_plays_for_day
+
+# These two call ESPN for real and assert exact counts against whatever it
+# serves back, so they check the live API rather than this code. Worth
+# keeping and worth running -- a `pytest` with no arguments still runs them
+# -- but not worth wiring a merge gate to, which is what putting them in CI
+# would do: the build would then fail for an ESPN outage, a rate limit, or a
+# play-by-play someone upstream revised.
+pytestmark = pytest.mark.network
 
 
 async def test_plays() -> None:

--- a/py-endgame/pyproject.toml
+++ b/py-endgame/pyproject.toml
@@ -30,6 +30,12 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    # Calls a third-party API for real. Runs by default, so a local `pytest`
+    # is unchanged; CI deselects it with `-m "not network"` -- see the
+    # workflow for why.
+    "network: talks to a live third-party API",
+]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
CI lints both packages and has never run `pytest`. 174 tests have been sitting in the repo gating nothing.

Adding NCAAFB week 0 ([#61](https://github.com/NathanDeMaria/EndGame/pull/61)) is what turned it up — the tests written for that change would have passed or failed entirely unobserved. This branch is off `main` and independent of #61, so it can go in either order.

## What's added

A `test` job running `py-endgame`'s suite, and `make-push` now needs it — so a red test stops the image rather than shipping alongside it.

## Only py-endgame gets a job

`py-endgame-aws` has no tests a merge gate can run:

| File | What it actually is |
|---|---|
| `endgame_aws/stores_test.py` | lists a real S3 bucket — a live-AWS integration test |
| `main_test.py` | a hand-run script: `if __name__ == "__main__": asyncio.run(plays(...))`, no test functions |

Matrixing over both would mean wiring AWS credentials into a job that currently needs none, to run one integration test and one file that only fails at import. So the job is deliberately not matrixed, with a comment saying why.

Worth knowing separately, not fixed here: **`main_test.py` matches pytest's `*_test.py` pattern but isn't a test**, and importing it raises `FileNotFoundError: Config file not found` because `cli.py` builds `Config.init_from_file()` at import time. Anyone who later adds pytest to that package hits this immediately. Renaming it to something outside the test pattern would be the fix — happy to, it just isn't this PR's job.

## The two network tests

`ncaabb/plays_test.py` is marked `network` and deselected in CI:

```python
async def test_plays() -> None:
    plays = await get_plays("401825568", NcaabbGender.mens)
    assert len(plays) == 492
```

These call ESPN for real and assert exact counts — 492 plays in one game, 17,720 in one day — so they check the live API more than they check this code.

To be explicit, since deselecting tests deserves scrutiny: **this isn't because they fail.** They may well pass on a GitHub runner; they fail in my sandbox only because its egress policy blocks ESPN. They're excluded because gating merges on them means an ESPN outage, a rate limit, or a play-by-play revised upstream fails a build for reasons that have nothing to do with the commit.

They stay in the repo and stay running:

- a bare `pytest` runs them, so local behaviour is unchanged
- `pytest -m network` runs only them
- the marker is registered in `pyproject.toml`, so no `PytestUnknownMarkWarning`

If you'd rather CI ran them too, deleting `-m "not network"` is the whole change.

## Verification

```
174 passed, 2 deselected in 0.66s     # what CI will run
176 tests collected                    # what a bare pytest still collects
```

`ruff format --check`, `ruff check` and `ty check` clean on `py-endgame`. The workflow YAML parses, and `make-push` resolves to `needs: [lint, test]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pcitn8aph8CNZ521f7AY9e)_