### PR TITLE
Let a caller re-pull a season the cache would answer for

### DIFF
--- a/py-endgame/endgame/ncaafb.py
+++ b/py-endgame/endgame/ncaafb.py
@@ -76,14 +76,32 @@ def _week_params(year: int) -> List[WeekParams]:
     return week_params
 
 
-async def get_season(year: int) -> Season:
+async def get_season(
+    year: int,
+    # Keyword-only so the positional signature stays `(year,)`, which is what
+    # `apply_in_parallel` unpacks its arg tuples into.
+    *,
+    use_cache: bool = True,
+    season_cache: SeasonCache | None = None,
+) -> Season:
     """
     Get the games from a season of NCAAFB
+
+    `use_cache=False` neither reads nor writes the season cache, for a
+    caller that is re-pulling precisely because what's cached is known to
+    be incomplete. That is not hypothetical: the cache is written for
+    every season that has ended, so a machine that has ever pulled these
+    years has one, and `backfill_week_zero` -- whose whole job is to fetch
+    the week 0 those cached seasons predate -- got an instant cache hit
+    and reported that every season gained nothing.
+
+    Note it leaves the cache alone rather than refreshing it, so a dry run
+    stays a dry run. Delete `~/.endgame/cache/season/ncaafb/` (or
+    `$ENDGAME_CACHE_DIR`) if you want local pulls corrected too.
     """
     logger.info("Getting NCAA season %s", year)
-    cache = SeasonCache("ncaafb")
-    season = cache.check_cache(year)
-    # TODO: add an option to ignore the cache if it has any skipped weeks?
+    cache = season_cache or SeasonCache("ncaafb")
+    season = cache.check_cache(year) if use_cache else None
     if season:
         return season.with_season_start(SEASON_START)
 
@@ -108,9 +126,11 @@ async def get_season(year: int) -> Season:
     weeks = list(_remove_cross_division_duplicates(weeks))
     season = Season(weeks, year, trouble_weeks, SEASON_START)
 
-    # Cache if the season is over
+    # Cache if the season is over -- and only if we were allowed to read it,
+    # since `save_to_cache` refuses to overwrite and a bypassing caller has
+    # no business replacing what it deliberately ignored.
     season_end_date = datetime(year + 1, *SEASON_END, tzinfo=timezone.utc)
-    if datetime.now(timezone.utc) > season_end_date:
+    if use_cache and datetime.now(timezone.utc) > season_end_date:
         cache.save_to_cache(season)
 
     return season

--- a/py-endgame/endgame/ncaafb_test.py
+++ b/py-endgame/endgame/ncaafb_test.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
 
+from . import ncaafb
 from .ncaafb import FIRST_WEEK_ZERO_SEASON, SEASON_START, _week_params
+from .season_cache import SeasonCache
 from .types import (
     Game,
     NcaaFbGroup,
@@ -98,3 +101,69 @@ def test_the_rest_of_the_season_is_unchanged_either_side_of_the_gate() -> None:
         (0, SeasonType.regular, group) for group in NcaaFbGroup
     }
     assert without_year(without) - without_year(with_zero) == set()
+
+
+class _FakeSeasonCache(SeasonCache):
+    """A SeasonCache held in memory, so tests never touch the real one."""
+
+    def __init__(self, cached: Season | None = None) -> None:
+        super().__init__("fake")
+        self._cached = cached
+        self.saved: list[Season] = []
+
+    def check_cache(self, season: int) -> Season | None:
+        return self._cached
+
+    def save_to_cache(self, season: Season) -> None:
+        self.saved.append(season)
+
+
+def _cached_season(year: int = 2016) -> Season:
+    """A season as it was written before week 0 was ever asked for."""
+    return Season([Week([_game(9, 10, "week-one", year)], 1)], year, [], SEASON_START)
+
+
+class TestIgnoringTheCache:
+    """`backfill_week_zero` re-pulls seasons *because* what's saved is stale.
+
+    The season cache is written for every season that has ended, so any
+    machine that has pulled these years has one -- and a cache hit returns
+    the pre-week-0 season without a single request. The backfill's first
+    real run reported that every season gained nothing, which is exactly
+    what that looks like from outside.
+    """
+
+    async def test_a_cache_hit_short_circuits_the_fetch(self) -> None:
+        """The behaviour being opted out of, pinned so it stays deliberate."""
+        cache = _FakeSeasonCache(_cached_season())
+
+        with patch.object(ncaafb, "_get_week", AsyncMock()) as get_week:
+            season = await ncaafb.get_season(2016, season_cache=cache)
+
+        get_week.assert_not_awaited()
+        assert [g.game_id for w in season.weeks for g in w.games] == ["week-one"]
+
+    async def test_use_cache_false_fetches_anyway(self) -> None:
+        cache = _FakeSeasonCache(_cached_season())
+
+        with patch.object(
+            ncaafb, "_get_week", AsyncMock(return_value=Week([], 0))
+        ) as get_week:
+            await ncaafb.get_season(2016, use_cache=False, season_cache=cache)
+
+        # And it asks for week 0, which is the whole point of re-pulling.
+        assert get_week.await_count == len(_week_params(2016))
+        assert 0 in {call.args[1] for call in get_week.await_args_list}
+
+    async def test_it_leaves_the_cache_alone(self) -> None:
+        """A dry run has to stay a dry run.
+
+        `save_to_cache` also refuses to overwrite, so writing here would
+        raise on every season that already has one.
+        """
+        cache = _FakeSeasonCache(_cached_season())
+
+        with patch.object(ncaafb, "_get_week", AsyncMock(return_value=Week([], 0))):
+            await ncaafb.get_season(2016, use_cache=False, season_cache=cache)
+
+        assert cache.saved == []


### PR DESCRIPTION
`backfill_week_zero` reported **+0 games for every season**, and the reason is that it never asked ESPN anything.

## What happened

`get_season` checks the season cache first:

```python
cache = SeasonCache("ncaafb")
season = cache.check_cache(year)
if season:
    return season.with_season_start(SEASON_START)
```

And the cache is written for **every season that has ended**:

```python
if datetime.now(timezone.utc) > season_end_date:
    cache.save_to_cache(season)
```

So any machine that has ever pulled these years has `~/.endgame/cache/season/ncaafb/{year}.pkl` sitting on disk. The backfill exists precisely to fetch the week 0 those cached seasons predate — and it got handed the pre-week-0 season straight back, from disk, without a request. Merging a season into itself is a no-op, which renders as `+0` and reads exactly like *"ESPN has no week 0 for this year"*.

Mea culpa: I flagged this trap when we designed the backfill and then shipped a command that walks into it.

## Unblocking without waiting for this

Non-destructive, works against `main` as it stands today — point the cache somewhere empty for one run:

```sh
ENDGAME_CACHE_DIR=$(mktemp -d) endgame-aws backfill_week_zero --first_year 2016 --last_year 2016
```

`CONFIG.cache_dir` reads the env var at access time, so this misses every existing entry and leaves your real cache untouched. (`rm -rf ~/.endgame/cache/season/ncaafb/` works too, but throws the cache away.)

**The tell either way:** a real run is dozens of requests per season and logs a `Getting NCAAFB {year} regular week {N} for {group}` line for each. A run that finishes instantly with none of those is a cache hit.

## The fix

`use_cache=False` neither reads nor writes the cache, so a caller re-pulling *because* the cached copy is known to be incomplete gets a real fetch.

It deliberately doesn't refresh the cache either — the backfill's dry run has to stay a dry run, and `save_to_cache` refuses to overwrite anyway, so writing would raise on every season that already has one. The docstring says to delete the cache dir if you want local pulls corrected too.

`season_cache` becomes injectable alongside it, the way `get_ncaabb_season`'s already is, so tests don't patch a module global or touch a real cache directory.

Both are **keyword-only**: `update()` fans out through `apply_in_parallel`, which unpacks positional arg tuples, so widening the positional signature makes every call site's `(year,)` the wrong shape. `ty` catches this, which is how I found it.

## Tests

```
184 passed, 2 deselected
```

Three new, including one pinning the **cache-hit path itself** — the behaviour being opted out of is worth keeping deliberate rather than leaving as the thing that happens to work:

| | |
|---|---|
| `test_a_cache_hit_short_circuits_the_fetch` | `_get_week` never awaited when a cache exists |
| `test_use_cache_false_fetches_anyway` | every week requested, **including week 0** |
| `test_it_leaves_the_cache_alone` | nothing saved, so a dry run stays dry |

`ruff format --check`, `ruff check`, `ty check` clean.

## Follow-up

The backfill's call site needs `get_ncaafb_season(year, use_cache=False)`, which can't lint until `py-endgame-aws`'s pin moves to this merge — same split as [#61](https://github.com/NathanDeMaria/EndGame/pull/61)/[#63](https://github.com/NathanDeMaria/EndGame/pull/63). It's written and pushed on `claude/backfill-ignores-the-cache-aws`; I'll bump and open it once this lands. Until then the env-var above does the same job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pcitn8aph8CNZ521f7AY9e)_