### PR TITLE
Run devcontainer as non-root dev user instead of root

### DIFF
--- a/py-endgame-aws/.devcontainer/Dockerfile
+++ b/py-endgame-aws/.devcontainer/Dockerfile
@@ -4,6 +4,8 @@ FROM python@sha256:0cfd98c036493924a8f80c343aeb1d14a23e8ef4c8c18c7932c36c80fa2e7
 # Poetry gets its own venv so its dependencies can't collide with the app's:
 # poetry.toml sets virtualenvs.create = false, so app deps land in the system
 # site-packages. This is what install.python-poetry.org does, minus the curl.
+# Root-owned deliberately -- `dev` below only ever executes poetry, it never
+# installs into it.
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=2.1.3
 RUN python3 -m venv "$POETRY_HOME" \
@@ -14,8 +16,56 @@ RUN python3 -m venv "$POETRY_HOME" \
 # copies, and ENTRYPOINT runs a bare `python` -- it must stay the system one
 # that `poetry install` populated.
 
-COPY poetry.* ./
-COPY pyproject.toml ./
+# Non-root, uid/gid 1000 to match the host user whose files get bind-mounted in
+# (~/.aws, ~/.claude, ~/.endgame). Running as root here meant every SSO token
+# refresh clobbered the host's cache with root-owned files. The runtime stage
+# inherits the user rather than switching back: it has nothing to do as root,
+# and one user across every stage means ~/.endgame/cache and
+# ~/.aws-batch/config.json resolve to the same paths in a Batch job as on a
+# laptop.
+#
+# The chown is because poetry.toml turns virtualenvs off, so /usr/local *is*
+# the environment. Three paths under it have to be writable by dev:
+#   site-packages  installed packages
+#   bin            console scripts (`endgame`, `endgame-aws`)
+#   src            git checkouts. Poetry clones VCS deps -- `endgame` is one --
+#                  into `env.path / "src"`, NOT into the cache dir, so with no
+#                  virtualenv that resolves to /usr/local/src, and a root-owned
+#                  one fails the install with EPERM.
+# The rest of the stdlib stays root-owned; chowning it would copy ~50M into
+# this layer for nothing. Here rather than after the install below so the chown
+# walks an empty site-packages.
+#
+# site-packages is looked up rather than spelled out, so this survives the
+# python bump the pinned digest above is going to get eventually.
+RUN apt-get update && apt-get install -y --no-install-recommends sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 dev \
+    && useradd --uid 1000 --gid 1000 -m -s /bin/bash dev \
+    && echo "dev ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/dev \
+    && chmod 0440 /etc/sudoers.d/dev \
+    && mkdir -p /usr/local/src \
+    && chown -R dev:dev \
+        "$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" \
+        /usr/local/bin \
+        /usr/local/src
+
+USER dev
+WORKDIR /home/dev
+
+# Parents of the bind mounts in devcontainer.json. Docker creates a missing
+# mount point as root, and chowning on the host can't fix these because the
+# parents themselves aren't mounted -- so `aws configure` and anything else
+# writing a new file straight into ~/.aws would hit EPERM. Pre-creating them as
+# dev means docker finds them already there and leaves ownership alone.
+# ~/.endgame is also where a Batch job writes its game cache.
+RUN mkdir -p /home/dev/.aws /home/dev/.aws-batch /home/dev/.endgame
+
+# Claude Code and anything else installed per-user lands here.
+ENV PATH="/home/dev/.local/bin:${PATH}"
+
+COPY --chown=dev:dev poetry.* ./
+COPY --chown=dev:dev pyproject.toml ./
 RUN poetry install --no-root --only main
 
 
@@ -24,9 +74,9 @@ RUN poetry install --no-root --only main
 FROM base AS runtime
 
 # Copying everything outside of the workdir, for use as a deployed Docker image
-ADD . /root/runtime
+ADD --chown=dev:dev . /home/dev/runtime
 
-ENTRYPOINT ["python", "/root/runtime/main.py"]
+ENTRYPOINT ["python", "/home/dev/runtime/main.py"]
 CMD ["--", "--help"]
 
 
@@ -36,25 +86,69 @@ FROM base AS dev
 
 RUN poetry install --no-root
 
+# The installers that write outside $HOME. `sudo` rather than a `USER root` /
+# `USER dev` sandwich so the layer's files land owned by whoever should own
+# them without a follow-up chown.
+#
 # Only needed for interactive use (`aws sso login`, `make push`) -- nothing in
 # endgame_aws shells out to the CLI, it goes through aiobotocore.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" &&\
     unzip awscliv2.zip &&\
-    ./aws/install &&\
+    sudo ./aws/install &&\
     rm awscliv2.zip &&\
     rm -r ./aws
 
+# GitHub CLI, for PR and issue work from a Claude session. Debian ships no
+# usable gh package and the upstream apt repo would be an unpinned external
+# source, so this takes the release .deb at a pinned version instead. dpkg
+# rather than apt-get because the package lists are deleted above; gh's only
+# dependency is git, which the base image already has.
+ARG GH_VERSION=2.97.0
+RUN arch="$(dpkg --print-architecture)" \
+    && curl -fsSL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${arch}.deb" \
+    && sudo dpkg -i /tmp/gh.deb \
+    && rm /tmp/gh.deb
+
+# jq, for the Makefile's IMAGE_URL: `make build` and `make push` read the ECR
+# repo url out of config.json with it, and without jq make prints
+# "jq: No such file or directory" on *every* invocation -- including targets
+# that never look at IMAGE_URL, because that line is a `$(shell ...)` make
+# expands up front. Interactive-only, like the awscli: the runtime stage gets
+# built by `make push`, it doesn't run it.
+RUN sudo apt-get update \
+    && sudo apt-get install -y --no-install-recommends jq \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Claude Code, pinned like poetry above. Installs the native build to
+# ~/.local/share/claude/versions/<v> and symlinks a launcher into ~/.local/bin,
+# which the PATH in `base` already covers. The installer's scratch dir
+# (~/.claude/downloads) is emptied before the layer closes, so nothing here
+# collides with the ~/.claude bind mount at runtime. Auto-updates still run
+# inside a live container; this only pins what a fresh build starts from.
+#
+# The native build is glibc-linked; bullseye's 2.31 is the oldest it supports.
+# If this ever starts failing with a `GLIBC_2.xx not found`, the fix is to move
+# the FROM above to a bookworm digest, not to drop back to the npm install.
+RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.235
+
+# Claude's top-level config lives at $HOME/.claude.json, which is *outside* the
+# ~/.claude bind mount -- so a rebuild loses it and the first `claude` run
+# replays the onboarding prompts. Seeding these two keys skips that; Claude
+# fills in the rest of the file on first run.
+RUN printf '%s' '{"hasCompletedOnboarding":true,"theme":"dark"}' \
+    > /home/dev/.claude.json
+
 # For persisting bash history
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" && echo $SNIPPET >> "/root/.bashrc"
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" && echo $SNIPPET >> "/home/dev/.bashrc"
 
 # Is this a good way to add stuff on load?
 # Not sure, but it's working
-COPY profile.sh /root/profile.sh
-RUN echo ". /root/profile.sh" >> "/root/.bashrc"
+COPY --chown=dev:dev profile.sh /home/dev/profile.sh
+RUN echo ". /home/dev/profile.sh" >> "/home/dev/.bashrc"
 
-RUN endgame -- --completion bash > ~/.endgame-completion.sh && echo ". ~/.endgame-completion.sh" >> "/root/.bashrc"
+RUN endgame -- --completion bash > ~/.endgame-completion.sh && echo ". ~/.endgame-completion.sh" >> "/home/dev/.bashrc"
 
 # `endgame-aws` can't do the same at build time: it's the root package, which
 # `poetry install --no-root` above skips deliberately (the source isn't in the
 # image, it's the workspace mount). postStartCommand writes the script instead.
-RUN echo 'if [ -f ~/.endgame-aws-completion.sh ]; then . ~/.endgame-aws-completion.sh; fi' >> "/root/.bashrc"
+RUN echo 'if [ -f ~/.endgame-aws-completion.sh ]; then . ~/.endgame-aws-completion.sh; fi' >> "/home/dev/.bashrc"

--- a/py-endgame-aws/.devcontainer/Dockerfile
+++ b/py-endgame-aws/.devcontainer/Dockerfile
@@ -92,11 +92,16 @@ RUN poetry install --no-root
 #
 # Only needed for interactive use (`aws sso login`, `make push`) -- nothing in
 # endgame_aws shells out to the CLI, it goes through aiobotocore.
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" &&\
-    unzip awscliv2.zip &&\
-    sudo ./aws/install &&\
-    rm awscliv2.zip &&\
-    rm -r ./aws
+#
+# `uname -m` because that is how the AWS CLI spells the arch in its download
+# urls (x86_64 / aarch64) -- `awscli-exe-linux-amd64.zip` is a 404. Not the
+# `dpkg --print-architecture` used for gh below, which spells the same two
+# machines amd64 / arm64 because that is what Debian package names use.
+RUN arch="$(uname -m)" \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${arch}.zip" -o awscliv2.zip \
+    && unzip -q awscliv2.zip \
+    && sudo ./aws/install \
+    && rm -rf awscliv2.zip ./aws
 
 # GitHub CLI, for PR and issue work from a Claude session. Debian ships no
 # usable gh package and the upstream apt repo would be an unpinned external
@@ -136,6 +141,26 @@ RUN printf '%s' '{"hasCompletedOnboarding":true,"theme":"dark"}' \
 
 # For persisting bash history
 RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" && echo $SNIPPET >> "/home/dev/.bashrc"
+
+# Machine-local environment -- the AWS_PROFILE to log into, mainly. It has to
+# be settable without committing it, so it lives in .devcontainer/local.env,
+# which .gitignore and .dockerignore both drop; devcontainer.json passes its
+# path down as DEVCONTAINER_ENV_FILE (from ${containerWorkspaceFolder}, since
+# where the workspace lands depends on which folder you opened).
+#
+# Sourced from two places on purpose, because bash reads different files
+# depending on how it was started and both cases matter here:
+#   .bashrc    interactive shells -- a VS Code terminal
+#   BASH_ENV   non-interactive ones -- `bash -c`, which is how Claude Code and
+#              anything scripted runs commands
+# Between them every bash in the container ends up with the profile set,
+# rather than just the ones a human typed into.
+#
+# Keep this script silent: BASH_ENV is read before *every* non-interactive
+# bash, so anything it prints lands in the output of every `$(...)` capture.
+COPY --chown=dev:dev .devcontainer/local-env.sh /home/dev/.local-env.sh
+ENV BASH_ENV=/home/dev/.local-env.sh
+RUN echo '. /home/dev/.local-env.sh' >> "/home/dev/.bashrc"
 
 # Is this a good way to add stuff on load?
 # Not sure, but it's working

--- a/py-endgame-aws/.devcontainer/Dockerfile
+++ b/py-endgame-aws/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# 3.13.4-bullseye on 2025-06-08
-FROM python@sha256:0cfd98c036493924a8f80c343aeb1d14a23e8ef4c8c18c7932c36c80fa2e72aa AS base
+# 3.14.7-trixie on 2026-08-29
+FROM python@sha256:48651f00145ad01e9f83d468c57cec40fac72081950f9730205b87abc6087552 AS base
 
 # Poetry gets its own venv so its dependencies can't collide with the app's:
 # poetry.toml sets virtualenvs.create = false, so app deps land in the system
@@ -7,7 +7,7 @@ FROM python@sha256:0cfd98c036493924a8f80c343aeb1d14a23e8ef4c8c18c7932c36c80fa2e7
 # Root-owned deliberately -- `dev` below only ever executes poetry, it never
 # installs into it.
 ENV POETRY_HOME="/opt/poetry" \
-    POETRY_VERSION=2.1.3
+    POETRY_VERSION=2.4.2
 RUN python3 -m venv "$POETRY_HOME" \
     && "$POETRY_HOME/bin/pip" install --no-cache-dir "poetry==$POETRY_VERSION" \
     && ln -s "$POETRY_HOME/bin/poetry" /usr/local/bin/poetry
@@ -125,10 +125,6 @@ RUN sudo apt-get update \
 # (~/.claude/downloads) is emptied before the layer closes, so nothing here
 # collides with the ~/.claude bind mount at runtime. Auto-updates still run
 # inside a live container; this only pins what a fresh build starts from.
-#
-# The native build is glibc-linked; bullseye's 2.31 is the oldest it supports.
-# If this ever starts failing with a `GLIBC_2.xx not found`, the fix is to move
-# the FROM above to a bookworm digest, not to drop back to the npm install.
 RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.235
 
 # Claude's top-level config lives at $HOME/.claude.json, which is *outside* the

--- a/py-endgame-aws/.devcontainer/devcontainer.json
+++ b/py-endgame-aws/.devcontainer/devcontainer.json
@@ -12,51 +12,50 @@
         "editor.rulers": [
           88
         ],
-        "python.pythonPath": "/usr/local/bin/python",
-        "python.linting.enabled": true,
-        "python.linting.mypyEnabled": true,
-        "python.linting.mypyPath": "/usr/local/bin/mypy",
-        "python.linting.pylintEnabled": true,
-        "python.linting.pylintPath": "/usr/local/bin/pylint",
-        "python.linting.pylintArgs": [
-          "--enable=unused-import,unused-variable",
-          "--disable=missing-module-docstring",
-          "--max-line-length=88"
-        ],
-        "python.formatting.provider": "black",
-        "python.formatting.blackPath": "/usr/local/bin/black",
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
         "editor.formatOnSave": true,
         "python.testing.pytestArgs": [
           "."
         ],
         "python.testing.unittestEnabled": false,
-        "python.testing.nosetestsEnabled": false,
         "python.testing.pytestEnabled": true,
         "autoDocstring.docstringFormat": "numpy-notypes",
-        "jupyter.debugJustMyCode": false
+        "jupyter.debugJustMyCode": false,
+        "[python]": {
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit",
+            "source.fixAll": "explicit"
+          },
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        },
+        "search.useIgnoreFiles": true
       },
       "extensions": [
         "ms-python.python",
         "ms-python.vscode-pylance",
-        "sourcery.sourcery",
         "njpwerner.autodocstring",
+        "charliermarsh.ruff",
         "github.vscode-github-actions",
         "ms-toolsai.jupyter",
         "anthropic.claude-code"
       ]
     }
   },
+  "remoteUser": "dev",
+  "shutdownAction": "none",
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+  },
+  "postCreateCommand": "sudo chown -R $(id -u):$(id -g) /commandhistory && poetry install",
+  "postStartCommand": "endgame-aws -- --completion bash > ~/.endgame-aws-completion.sh && nohup flock -n /home/dev/.claude-rc.lock claude rc --name endgame-aws >>/tmp/claude-rc.log 2>&1 &",
   "mounts": [
     "source=bashhistory-volume,target=/commandhistory,type=volume",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.endgame/cache,target=/root/.endgame/cache,type=bind,consistency=cached",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/cache,target=/root/.endgame/cache,type=bind,consistency=cached",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/login,target=/root/.aws/login,type=bind,consistency=cached",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/sso,target=/root/.aws/sso,type=bind,consistency=cached",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/credentials,target=/root/.aws/credentials,type=bind,consistency=cached,ro=1",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/config,target=/root/.aws/config,type=bind,consistency=cached,ro=1",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/root/.claude,type=bind,consistency=cached",
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws-batch/config.json,target=/root/.aws-batch/config.json,type=bind,consistency=cached,ro=1"
-  ],
-  "postCreateCommand": "poetry install",
-  "postStartCommand": "endgame-aws -- --completion bash > ~/.endgame-aws-completion.sh"
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.endgame/cache,target=/home/dev/.endgame/cache,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/login,target=/home/dev/.aws/login,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/sso,target=/home/dev/.aws/sso,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/credentials,target=/home/dev/.aws/credentials,type=bind,consistency=cached,ro=1",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/config,target=/home/dev/.aws/config,type=bind,consistency=cached,ro=1",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/home/dev/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws-batch/config.json,target=/home/dev/.aws-batch/config.json,type=bind,consistency=cached,ro=1"
+  ]
 }

--- a/py-endgame-aws/.devcontainer/devcontainer.json
+++ b/py-endgame-aws/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
   "remoteUser": "dev",
   "shutdownAction": "none",
   "remoteEnv": {
-    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "DEVCONTAINER_ENV_FILE": "${containerWorkspaceFolder}/.devcontainer/local.env"
   },
   "postCreateCommand": "sudo chown -R $(id -u):$(id -g) /commandhistory && poetry install",
   "postStartCommand": "endgame-aws -- --completion bash > ~/.endgame-aws-completion.sh && nohup flock -n /home/dev/.claude-rc.lock claude rc --name endgame-aws >>/tmp/claude-rc.log 2>&1 &",

--- a/py-endgame-aws/.devcontainer/local-env.sh
+++ b/py-endgame-aws/.devcontainer/local-env.sh
@@ -1,0 +1,14 @@
+# Sourced by every bash in the devcontainer -- from .bashrc when interactive,
+# from BASH_ENV when not. See the block that installs it in ./Dockerfile.
+#
+# Keep this silent and cheap. BASH_ENV means it runs ahead of every
+# non-interactive bash, so anything printed here ends up inside the output of
+# every `$(...)` in every script that runs in this container.
+
+# The machine-local settings themselves (AWS_PROFILE and anything else that
+# shouldn't be committed) live in .devcontainer/local.env, which is gitignored.
+# devcontainer.json passes its path down as DEVCONTAINER_ENV_FILE; the file
+# itself is optional, and absent it everything just behaves as it did before.
+if [ -f "${DEVCONTAINER_ENV_FILE:-}" ]; then
+    . "${DEVCONTAINER_ENV_FILE}"
+fi

--- a/py-endgame-aws/.devcontainer/local.env.example
+++ b/py-endgame-aws/.devcontainer/local.env.example
@@ -1,0 +1,7 @@
+# Copy to local.env -- that name is gitignored, this one is tracked as the
+# reference. Sourced by every bash in the container, so `aws sso login`, boto,
+# and anything Claude Code runs all agree on which profile they're using.
+#
+# The profile name has to match a [profile ...] section in the ~/.aws/config
+# that devcontainer.json mounts in from the host.
+export AWS_PROFILE=your-sso-profile

--- a/py-endgame-aws/.dockerignore
+++ b/py-endgame-aws/.dockerignore
@@ -10,4 +10,9 @@ scratch/
 
 # NOTE: config.json is deliberately NOT ignored. endgame_aws/config.py resolves
 # it relative to the package root, so the deployed image needs it at
-# /root/runtime/config.json -- main.py reads it at import time.
+# /home/dev/runtime/config.json -- main.py reads it at import time.
+
+# Machine-local settings, deliberately not baked into a deployed image. `**/`
+# because .dockerignore's `*` doesn't cross a `/`, and this one lives in
+# .devcontainer/.
+**/*.env

--- a/py-endgame-aws/.gitignore
+++ b/py-endgame-aws/.gitignore
@@ -1,2 +1,7 @@
 config.json
 scratch/*
+
+# Machine-local devcontainer settings -- the AWS_PROFILE to use, mainly. The
+# point of the file is to keep that out of here; local.env.example is the
+# tracked copy that documents it.
+.devcontainer/local.env


### PR DESCRIPTION
## Summary
Refactored the devcontainer to run as a non-root user (`dev` with uid/gid 1000) instead of root. This prevents permission issues when bind-mounting host directories like `~/.aws` and `~/.endgame`, where SSO token refreshes and cache writes would otherwise create root-owned files on the host.

## Key Changes

- **User and permissions**: Created a non-root `dev` user (uid/gid 1000) and configured appropriate ownership of `/usr/local/bin`, `/usr/local/site-packages`, and `/usr/local/src` to allow package installation and VCS dependency cloning
- **Base image update**: Upgraded Python from 3.13.4-bullseye to 3.14.7-trixie and Poetry from 2.1.3 to 2.4.2
- **Home directory**: Changed all paths from `/root` to `/home/dev` throughout the Dockerfile and devcontainer configuration
- **Bind mount targets**: Updated all devcontainer.json mount points to target `/home/dev` instead of `/root` (`.aws`, `.endgame`, `.claude`, `.aws-batch`)
- **New tooling**: Added GitHub CLI (gh) and jq for interactive use, plus Claude Code with pinned version 2.1.235
- **Environment configuration**: 
  - Created `local-env.sh` script sourced by both interactive and non-interactive bash shells to load machine-local settings
  - Added `local.env.example` template for AWS_PROFILE configuration
  - Set up `BASH_ENV` to ensure environment variables are available in all bash contexts
- **VS Code settings**: Updated deprecated Python extension settings (`pythonPath` → `defaultInterpreterPath`, removed deprecated linting/formatting options) and switched to Ruff for code formatting
- **Build improvements**: Enhanced AWS CLI and gh installation with better error handling (`-fsSL` flags) and architecture detection; added sudo for privileged operations during build
- **Documentation**: Added extensive comments explaining the rationale for user creation, permission model, and environment variable sourcing strategy

## Notable Implementation Details

- The `chown` of `/usr/local` paths happens before dependency installation to avoid copying large amounts of data in a later layer
- Pre-creates bind mount parent directories (`~/.aws`, `~/.endgame`, `~/.aws-batch`) as the `dev` user to prevent Docker from creating them as root
- Uses `sudo` for privileged operations (AWS CLI install, package management) rather than switching users, ensuring files are owned by the correct user without additional chown layers
- Implements dual-sourcing of environment configuration (`.bashrc` for interactive shells, `BASH_ENV` for non-interactive) to ensure consistent behavior across all bash invocations
- Removed the duplicate `.aws/cache` mount that was incorrectly targeting `.endgame/cache`

https://claude.ai/code/session_01QRqdBcSvyrhqiRGfVn39Jf